### PR TITLE
Add industry DSR (checkpoint profiles, stores, and configs)

### DIFF
--- a/config/examples/config.industry.dsr.technology.yaml
+++ b/config/examples/config.industry.dsr.technology.yaml
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Example configuration for technology-specific industry DSR
+# This extends the base industry DSR configuration with technology breakdowns
+#
+# IMPORTANT: When technology_breakdown is provided, DSR is ONLY applied to profiles
+# that have a technology breakdown defined. Other profiles will NOT get DSR stores,
+# even if they have profile-level flexibility_fraction/shift_hours defined.
+#
+# This config should be merged with a base config that has industry.dsr.enable: true
+
+industry:
+  dsr:
+    enable: true
+    
+    # Technology breakdown: defines how each FfE profile is split into technologies
+    # Shares must sum to 1.0 per profile
+    # You can define breakdowns for any profile, or leave profiles without breakdown to use profile-level flexibility
+    technology_breakdown:
+      "Iron & steel industry":
+        # ⚠️ IMPORTANT: "Iron & steel industry" FfE profile includes BOTH steel AND aluminium
+        # 
+        # OPTION 1: Auto-calculate shares from production data (recommended)
+        # Set shares to "auto" and the model will calculate them from production data:
+        "Scrap-EAF": "auto"           # Auto-calculate from "Electric arc" production
+        "H2-DRI-EAF": "auto"          # Auto-calculate from "DRI + Electric arc" production
+        "BF-BOF-CCUS": "auto"         # Auto-calculate from "Integrated steelworks" production
+        "Aluminium-primary": "auto"    # Auto-calculate from "Aluminium - primary production" production
+        "Aluminium-secondary": "auto" # Auto-calculate from "Aluminium - secondary production" production
+        "Alumina": "auto"             # Auto-calculate from "Alumina production" production
+        "Manufacturing": 0.05         # Fixed share for inflexible manufacturing (not in production data)
+        #
+        # OPTION 2: Manual shares (if you want to override auto-calculation)
+        # Calculate the actual shares from your production data:
+        # - Steel load = sum of (Electric arc, DRI + Electric arc, Integrated steelworks) electricity
+        # - Aluminium load = sum of (Aluminium - primary, Aluminium - secondary, Alumina) electricity
+        # - Total = Steel load + Aluminium load
+        # - Steel share = Steel load / Total
+        # - Aluminium share = Aluminium load / Total
+        #
+        # Example manual shares:
+        # "Scrap-EAF": 0.25
+        # "H2-DRI-EAF": 0.40
+        # "BF-BOF-CCUS": 0.10
+        # "Aluminium-primary": 0.10
+        # "Aluminium-secondary": 0.08
+        # "Alumina": 0.02
+        # "Manufacturing": 0.05
+        # Total should sum to 1.0
+      "Non-metallic Minerals":
+        "Cement mills": 0.40    # 40% of cement load is cement mills (grinding, 4h shiftable)
+        "Raw mills": 0.26       # 26% is raw mills (grinding, 4h shiftable)
+        "Kiln": 0.27           # 27% is kiln (NOT flexible, continuous 24h operation)
+        "Other": 0.07          # 7% other processes (not flexible)
+      "Paper, Pulp and Print":
+        "Pulp production": 0.30  # 30% of load is pulp production (flexible)
+        "Paper machines": 0.50   # 50% of load is paper machines (NOT flexible)
+        "Printing": 0.20         # 20% of load is printing (flexible)
+      "Non-specified (Industry)":
+        # ⚠️ IMPORTANT: "Non-specified (Industry)" includes MANY sectors:
+        # - HVC (High Value Chemicals)
+        # - HVC (mechanical recycling)
+        # - HVC (chemical recycling)
+        # - Ammonia
+        # - Chlorine (chlor-alkali)
+        # - Methanol
+        # - Other chemicals
+        # - Pharmaceutical products etc.
+        # - Other non-ferrous metals
+        # - Other industrial sectors
+        #
+        # The shares below represent the FRACTION of total "Non-specified (Industry)" load
+        # that each technology represents. They MUST sum to 1.0.
+        #
+        # You MUST calculate the actual shares from your production data:
+        # Example for chlor-alkali:
+        #   chlorine_electricity = chlorine_production_today × MWh_elec_per_tCl
+        #   total_non_specified_electricity = sum of all "Non-specified (Industry)" electricity
+        #   chlor_alkali_share = chlorine_electricity / total_non_specified_electricity
+        #
+        # The values below are EXAMPLES - adjust based on your actual data!
+        "Chlor-alkali": 0.10      # EXAMPLE: Adjust based on actual chlorine production share!
+        "Other chemicals": 0.90   # EXAMPLE: Should include HVC, Ammonia, Methanol, etc.
+    
+    # Technology-specific flexibility_fraction
+    # Format: "profile|technology": fraction
+    # For profiles WITH technology_breakdown: use "profile|technology" keys
+    # For profiles WITHOUT technology_breakdown: use "profile" keys (profile-level)
+    flexibility_fraction:
+      # Iron & steel industry technologies (has technology_breakdown)
+      # Based on EU context study (2.1 MtCS/yr plants), EU-derived price scenarios:
+      # - EAF: highly flexible (>80%) - differentiated approach recommended
+      # - H2-DRI: depends on electrolyser sizing
+      # - BF-BOF: minimal flexibility (expected phase-out)
+      # Steel technologies:
+      "Iron & steel industry|Scrap-EAF": 0.85     # >80% flexible (study recommendation), 1.5-2.5h shift
+      "Iron & steel industry|H2-DRI-EAF": 0.20    # 20% flexible (depends on electrolyser sizing), 4-8h shift
+      # ✓ NOTE: H2-DRI-EAF flexibility is now coupled to H2 storage capacity via constraints.
+      # The constraint limits DRI load shifting based on available H2 storage:
+      # |DRI_DSR_dispatch| ≤ H2_storage_capacity / (H2_DRI / elec_DRI)
+      # Where H2_DRI = 1.7 MWh_H2/t_steel and elec_DRI = 0.322 MWh_el/t_steel
+      # This means: |DRI_DSR_dispatch| ≤ H2_storage_capacity / 5.28
+      # If H2 storage is extendable, the optimizer can build more storage to enable more flexibility.
+      # The flexibility_fraction (0.20) sets the maximum potential, but actual flexibility
+      # will be limited by H2 storage capacity at each node.
+      "Iron & steel industry|BF-BOF-CCUS": 0.05   # 5% flexible (minimal, expected phase-out), waste heat recovery only
+      "Iron & steel industry|Manufacturing": 0.0  # Not flexible
+      # Aluminium technologies:
+      # Conservative scenario (pot on/off): 10-15% flexible, 2-4h shift
+      # Optimistic scenario (voltage control): 5-10% flexible, real-time capable
+      # Note: 34.2% mentioned in literature is economic flexibility, not physical. We model physical limits.
+      # Values below use conservative scenario. For optimistic, use 0.075 (7.5%) and consider shorter shift_hours (1-2h).
+      "Iron & steel industry|Aluminium-primary": 0.125   # Conservative: 12.5% flexible (midpoint of 10-15%)
+      "Iron & steel industry|Aluminium-secondary": 0.125 # Conservative: 12.5% flexible (same as primary)
+      "Iron & steel industry|Alumina": 0.0              # Alumina production: not flexible (continuous process)
+      # Non-metallic Minerals technologies (has technology_breakdown)
+      # Note: flexible_share 0.28 applies to grinding loads only (cement + raw mills = 66% of total)
+      # This means ~42% of cement mills load and ~42% of raw mills load is flexible (0.28/0.66 ≈ 0.42)
+      "Non-metallic Minerals|Cement mills": 0.42  # ~42% of cement mills load is flexible (4h shiftable)
+      "Non-metallic Minerals|Raw mills": 0.42     # ~42% of raw mills load is flexible (4h shiftable)
+      "Non-metallic Minerals|Kiln": 0.0           # Not flexible (continuous 24h operation)
+      "Non-metallic Minerals|Other": 0.0          # Not flexible
+      # Paper, Pulp and Print technologies (has technology_breakdown)
+      # flexible_share 0.30 applies to flexible processes (pulp + printing = 50% of total)
+      # This means ~60% of pulp production and ~60% of printing load is flexible (0.30/0.50 = 0.60)
+      "Paper, Pulp and Print|Pulp production": 0.60  # ~60% of pulp production load is flexible (0.30/0.50)
+      "Paper, Pulp and Print|Paper machines": 0.0    # NOT flexible (~50% of total load)
+      "Paper, Pulp and Print|Printing": 0.60         # ~60% of printing load is flexible (0.30/0.50)
+      # Non-specified (Industry) technologies (has technology_breakdown)
+      # IMPORTANT: The technology_breakdown shares below represent the FRACTION of the total
+      # "Non-specified (Industry)" load that each technology represents (must sum to 1.0).
+      # "Non-specified (Industry)" includes: HVC, Ammonia, Chlorine, Methanol, Other chemicals,
+      # Pharmaceutical products, Other non-ferrous metals, Other industrial sectors.
+      # You need to calculate the actual share of chlor-alkali based on your production data.
+      # Example calculation: chlorine_electricity = chlorine_production × MWh_elec_per_tCl
+      #                     chlor_alkali_share = chlorine_electricity / total_non_specified_electricity
+      # Chlor-alkali flexibility parameters (from literature):
+      # - flexible_share: 0.10 (10% flexible, negative only - load shedding, not upward)
+      # - min_load: 0.70 (hard operational constraint from column stability)
+      # - Applies to ~30% of Cl? (EDC/PVC route only)
+      # - Response time: hours (day-ahead compatible based on 24h simulation)
+      "Non-specified (Industry)|Chlor-alkali": 0.10   # 10% flexible, negative only (adjust share based on your data!)
+      # Other profiles WITHOUT technology_breakdown (use profile-level)
+      "Food and Tobacco": 0.10
+      "Non-specified (Industry)": 0.10
+      "Textile and Leather": 0.10
+      "Wood and Wood Products": 0.10
+      "Transport Equipment": 0.10
+      "Machinery": 0.10
+    
+    # Technology-specific shift_hours
+    # Format: "profile|technology": hours
+    # For profiles WITH technology_breakdown: use "profile|technology" keys
+    # For profiles WITHOUT technology_breakdown: use "profile" keys (profile-level)
+    shift_hours:
+      # Iron & steel industry technologies (has technology_breakdown)
+      # Steel technologies:
+      "Iron & steel industry|Scrap-EAF": 2        # 1.5-2.5h shift window
+      "Iron & steel industry|H2-DRI-EAF": 6       # 4-8h shift window (with H2 storage)
+      "Iron & steel industry|BF-BOF-CCUS": 1      # 1h shift window
+      # Aluminium technologies:
+      "Iron & steel industry|Aluminium-primary": 3     # Conservative: 3h shift window (midpoint of 2-4h)
+      "Iron & steel industry|Aluminium-secondary": 3   # Conservative: 3h shift window (same as primary)
+      "Iron & steel industry|Alumina": 0              # Alumina: not flexible (no shift hours)
+      # Non-metallic Minerals technologies (has technology_breakdown)
+      "Non-metallic Minerals|Cement mills": 4     # 4h shiftable (max hours can be off)
+      "Non-metallic Minerals|Raw mills": 4        # 4h shiftable (max hours can be off)
+      # Paper, Pulp and Print technologies (has technology_breakdown)
+      # shift_time: 24h, delay_time: 3-6h optimal (diminishing returns beyond 6h)
+      "Paper, Pulp and Print|Pulp production": 6  # 6h shift window (optimal delay_time)
+      "Paper, Pulp and Print|Printing": 6         # 6h shift window (optimal delay_time)
+      # Non-specified (Industry) technologies (has technology_breakdown)
+      "Non-specified (Industry)|Chlor-alkali": 4   # 4h shift window (example)
+      # Other profiles WITHOUT technology_breakdown (use profile-level)
+      "Food and Tobacco": 4
+      "Non-specified (Industry)": 4
+      "Textile and Leather": 4
+      "Wood and Wood Products": 4
+      "Transport Equipment": 4
+      "Machinery": 4
+    
+    # Technology-specific restriction_time (checkpoint hours)
+    # Format: "profile|technology": [hours] for technologies WITH breakdown
+    # Format: "profile": [hours] for profiles WITHOUT breakdown
+    # If not specified for a technology, inherits from profile-level
+    restriction_time:
+      # Iron & steel industry technologies (has technology_breakdown)
+      # Steel technologies:
+      "Iron & steel industry|Scrap-EAF": [6, 18]      # Checkpoints at 6:00 and 18:00
+      "Iron & steel industry|H2-DRI-EAF": [0, 12]     # Checkpoints at midnight and noon
+      "Iron & steel industry|BF-BOF-CCUS": [6, 18]     # Same as Scrap-EAF
+      # Aluminium technologies:
+      # Conservative (pot on/off): daily checkpoints to balance load
+      # Optimistic (voltage control): could use shorter/no checkpoints for real-time capability
+      "Iron & steel industry|Aluminium-primary": [0]    # Daily checkpoint at midnight (conservative scenario)
+      "Iron & steel industry|Aluminium-secondary": [0]   # Daily checkpoint at midnight (same as primary)
+      "Iron & steel industry|Alumina": [0]              # Alumina: checkpoint (though not flexible)
+      # Non-metallic Minerals technologies (has technology_breakdown)
+      # Daily energy balance: checkpoints ensure energy-neutral shifting within 24h
+      "Non-metallic Minerals|Cement mills": [0]         # Daily checkpoint at midnight (24h cycle)
+      "Non-metallic Minerals|Raw mills": [0]          # Daily checkpoint at midnight (24h cycle)
+      # Paper, Pulp and Print technologies (has technology_breakdown)
+      # shift_time: 24h, so daily checkpoint ensures energy-neutral shifting
+      "Paper, Pulp and Print|Pulp production": [0]     # Daily checkpoint at midnight (24h cycle)
+      "Paper, Pulp and Print|Printing": [0]           # Daily checkpoint at midnight (24h cycle)
+      # Non-specified (Industry) technologies (has technology_breakdown)
+      "Non-specified (Industry)|Chlor-alkali": [0]     # Daily checkpoint at midnight (24h cycle)
+      # Profile-level (used as fallback for technologies without specific restriction_time)
+      # Also used for profiles WITHOUT technology_breakdown
+      "Iron & steel industry": [6, 18]                 # Fallback for technologies without specific times
+      "Non-metallic Minerals": [0, 12]                 # Fallback for technologies without specific times
+      "Paper, Pulp and Print": [0]                     # Fallback for technologies without specific times (24h cycle)
+      "Non-specified (Industry)": [0]                  # Fallback for technologies without specific times
+      "Food and Tobacco": [8, 20]                      # Profile-level (no technology_breakdown)
+      "Non-specified (Industry)": [6, 18]              # Profile-level (no technology_breakdown)
+      "Textile and Leather": [8, 20]                   # Profile-level (no technology_breakdown)
+      "Wood and Wood Products": [8, 20]                # Profile-level (no technology_breakdown)
+      "Transport Equipment": [6, 18]                   # Profile-level (no technology_breakdown)
+      "Machinery": [6, 18]                             # Profile-level (no technology_breakdown)
+    
+    restriction_value: 1.0
+    
+    # Negative-only DSR: technologies that can only REDUCE load (discharge), not increase it (charge)
+    # Format: "profile|technology": true/false
+    # When true: e_max_pu = 0 (can't charge), e_min_pu = -max_reduction (can discharge)
+    # Note: With e_cyclic=True, the store must return to 0 at checkpoint hours, which may require
+    # allowing e_max_pu > 0 at checkpoints to enable return to zero state
+    negative_only:
+      "Non-specified (Industry)|Chlor-alkali": true   # Chlor-alkali: can only reduce load, not increase
+      # All other technologies default to false (bidirectional: can charge and discharge)
+    
+    # Minimum load constraint: hard operational constraint (fraction of baseline load)
+    # Format: "profile|technology": fraction (e.g., 0.70 = 70% minimum load)
+    # Example: min_load: 0.70 means load can only be reduced to 70% of baseline (max reduction = 30%)
+    # The actual maximum reduction is min(flexibility_fraction, 1.0 - min_load)
+    # Example: If flexibility_fraction = 0.10 and min_load = 0.70:
+    #   - max_reduction = min(0.10, 1.0 - 0.70) = min(0.10, 0.30) = 0.10 (10% reduction)
+    #   - Load can be reduced from 100% to 90% (not to 70%, because flexibility is only 10%)
+    # Example: If flexibility_fraction = 0.50 and min_load = 0.70:
+    #   - max_reduction = min(0.50, 1.0 - 0.70) = min(0.50, 0.30) = 0.30 (30% reduction)
+    #   - Load can be reduced from 100% to 70% (limited by min_load constraint)
+    min_load:
+      "Non-specified (Industry)|Chlor-alkali": 0.70   # Chlor-alkali: hard operational constraint (column stability)
+      # Load can only be reduced to 70% of baseline (max reduction = 30%)
+      # Applies to ~30% of Cl? (EDC/PVC route only)
+      # All other technologies default to None (no min_load constraint)

--- a/config/test/config.industry.flex.yaml
+++ b/config/test/config.industry.flex.yaml
@@ -17,7 +17,7 @@ remote:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   prefix: ""
-  name: ""
+  name: "Test_2030"
   scenarios:
     enable: false
     file: config/scenarios.yaml
@@ -34,50 +34,54 @@ foresight: overnight
 # Wildcard docs in https://pypsa-eur.readthedocs.io/en/latest/wildcards.html
 scenario:
   clusters:
-  - 50
+  - 5
   opts:
   - ''
   sector_opts:
   - ''
   planning_horizons:
-  - 2050
+  - 2030
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries
 countries:
-- AL
-- AT
-- BA
+# - DE
+# - NL
 - BE
-- BG
-- CH
-- CZ
-- DE
-- DK
-- EE
-- ES
-- FI
-- FR
-- GB
-- GR
-- HR
-- HU
-- IE
-- IT
-- LT
-- LU
-- LV
-- ME
-- MK
-- NL
-- 'NO'
-- PL
-- PT
-- RO
-- RS
-- SE
-- SI
-- SK
-- XK
+# - FR
+# - AL
+# - AT
+# - BA
+# - BE
+# - BG
+# - CH
+# - CZ
+# - DE
+# - DK
+# - EE
+# - ES
+# - FI
+# - FR
+# - GB
+# - GR
+# - HR
+# - HU
+# - IE
+# - IT
+# - LT
+# - LU
+# - LV
+# - ME
+# - MK
+# - NL
+# - 'NO'
+# - PL
+# - PT
+# - RO
+# - RS
+# - SE
+# - SI
+# - SK
+# - XK
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#snapshots
 snapshots:
@@ -88,6 +92,7 @@ snapshots:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
   drop_leap_day: true
+  retrieve: true
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#co2-budget
 co2_budget:
@@ -939,53 +944,97 @@ industry:
   hotmaps_locate_missing: false
   reference_year: 2019
   oil_refining_emissions: 0.013
+  temporal_electricity_industry_load: true
 
-  # Industry electricity demand-side response (DSR): virtual storage for load shifting.
-  # Config keys use FfE profile names (e.g. "Iron & steel industry"), not PyPSA industry categories
-  # (e.g. Electric arc, Cement). See INDUSTRY_CATEGORY_TO_PROFILE in build_industrial_energy_demand_per_node.py.
+  # Industry electricity DSR: virtual storage for load shifting (mirrors residential_heat.dsm).
+  # Technology-specific DSR implementation requires technology_breakdown to be defined.
   dsr:
-    enable: false
-    # Fraction of load that can be shifted (0..1) per FfE profile.
+    enable: true
+    
+    # Technology breakdown: defines how each FfE profile is split into technologies
+    # Only profiles with technology_breakdown will get DSR stores
+    # Profiles without technology_breakdown will NOT get DSR stores
+    technology_breakdown:
+      "Iron & steel industry":
+        "Scrap-EAF": "auto"           # Auto-calculate from production data
+        "H2-DRI-EAF": "auto"          # Auto-calculate from production data
+        "BF-BOF-CCUS": "auto"         # Auto-calculate from production data
+        "Manufacturing": 0.05          # Fixed share for inflexible processes
+        "Aluminium-primary": "auto"    # Auto-calculate from production data
+        "Aluminium-secondary": "auto"  # Auto-calculate from production data
+        "Alumina": "auto"              # Auto-calculate from production data
+      "Non-metallic Minerals":  # Cement
+        "Cement mills": 0.40    # 40% of cement load
+        "Raw mills": 0.26       # 26% of cement load
+        "Kiln": 0.27           # 27% of cement load (NOT flexible)
+        "Other": 0.07          # 7% other processes
+      "Paper, Pulp and Print":
+        "Pulp production": 0.30  # 30% of load
+        "Paper machines": 0.50   # 50% of load (NOT flexible)
+        "Printing": 0.20         # 20% of load
+    
+    # Technology-specific flexibility parameters
+    # Format: "profile|technology": value
     flexibility_fraction:
-      "Iron & steel industry": 0.15
-      "Non-metallic Minerals": 0.20
-      "Paper, Pulp and Print": 0.10
-      "Food and Tobacco": 0.10
-      "Non-specified (Industry)": 0.10
-      "Textile and Leather": 0.10
-      "Wood and Wood Products": 0.10
-      "Transport Equipment": 0.10
-      "Machinery": 0.10
-    # Maximum shift duration in hours per FfE profile (e.g. cement/NMM: 2h, pulp: 8h).
+      # Iron & steel industry technologies
+      "Iron & steel industry|Scrap-EAF": 0.85     # 85% flexible
+      "Iron & steel industry|H2-DRI-EAF": 0.20    # 20% flexible (coupled to H2 storage)
+      "Iron & steel industry|BF-BOF-CCUS": 0.05   # 5% flexible
+      "Iron & steel industry|Manufacturing": 0.0  # Not flexible
+      # Aluminium technologies
+      "Iron & steel industry|Aluminium-primary": 0.125   # Conservative: 12.5% flexible
+      "Iron & steel industry|Aluminium-secondary": 0.125 # Conservative: 12.5% flexible
+      "Iron & steel industry|Alumina": 0.0               # Not flexible
+      # Non-metallic Minerals (Cement) technologies
+      "Non-metallic Minerals|Cement mills": 0.42  # ~42% of cement mills load is flexible
+      "Non-metallic Minerals|Raw mills": 0.42     # ~42% of raw mills load is flexible
+      "Non-metallic Minerals|Kiln": 0.0           # Not flexible (continuous 24h operation)
+      "Non-metallic Minerals|Other": 0.0          # Not flexible
+      # Paper, Pulp and Print technologies
+      "Paper, Pulp and Print|Pulp production": 0.60  # ~60% of pulp production load is flexible
+      "Paper, Pulp and Print|Paper machines": 0.0    # NOT flexible (~50% of total load)
+      "Paper, Pulp and Print|Printing": 0.60         # ~60% of printing load is flexible
+    
     shift_hours:
-      "Iron & steel industry": 4
-      "Non-metallic Minerals": 2
-      "Paper, Pulp and Print": 8
-      "Food and Tobacco": 4
-      "Non-specified (Industry)": 4
-      "Textile and Leather": 4
-      "Wood and Wood Products": 4
-      "Transport Equipment": 4
-      "Machinery": 4
-    # Checkpoint hours (0-23) per FfE profile at which the DSR store must be empty; demand is balanced per period.
-    # Different sectors have different operating times (e.g. 24/7 vs day shift).
+      # Iron & steel industry technologies
+      "Iron & steel industry|Scrap-EAF": 2        # 2h shift window
+      "Iron & steel industry|H2-DRI-EAF": 6       # 6h shift window
+      "Iron & steel industry|BF-BOF-CCUS": 1      # 1h shift window
+      # Aluminium technologies
+      "Iron & steel industry|Aluminium-primary": 3     # 3h shift window
+      "Iron & steel industry|Aluminium-secondary": 3   # 3h shift window
+      # Non-metallic Minerals (Cement) technologies
+      "Non-metallic Minerals|Cement mills": 4     # 4h shiftable
+      "Non-metallic Minerals|Raw mills": 4        # 4h shiftable
+      # Paper, Pulp and Print technologies
+      "Paper, Pulp and Print|Pulp production": 6  # 6h shift window
+      "Paper, Pulp and Print|Printing": 6         # 6h shift window
+    
     restriction_time:
-      "Iron & steel industry": [6, 18]
-      "Non-metallic Minerals": [0, 12]
-      "Paper, Pulp and Print": [6, 22]
-      "Food and Tobacco": [8, 20]
-      "Non-specified (Industry)": [6, 18]
-      "Textile and Leather": [8, 20]
-      "Wood and Wood Products": [8, 20]
-      "Transport Equipment": [6, 18]
-      "Machinery": [6, 18]
-    # Scale factor (0..1) for DSR profile; 1.0 = full flexibility between checkpoints.
+      # Iron & steel industry technologies
+      "Iron & steel industry|Scrap-EAF": [6, 18]      # Checkpoints at 6:00 and 18:00
+      "Iron & steel industry|H2-DRI-EAF": [0, 12]     # Checkpoints at midnight and noon
+      "Iron & steel industry|BF-BOF-CCUS": [6, 18]     # Same as Scrap-EAF
+      # Aluminium technologies
+      "Iron & steel industry|Aluminium-primary": [0]    # Daily checkpoint at midnight
+      "Iron & steel industry|Aluminium-secondary": [0]   # Daily checkpoint at midnight
+      # Non-metallic Minerals (Cement) technologies
+      "Non-metallic Minerals|Cement mills": [0]    # Daily checkpoint at midnight
+      "Non-metallic Minerals|Raw mills": [0]       # Daily checkpoint at midnight
+      # Paper, Pulp and Print technologies
+      "Paper, Pulp and Print|Pulp production": [0]  # Daily checkpoint at midnight
+      "Paper, Pulp and Print|Printing": [0]         # Daily checkpoint at midnight
+    
     restriction_value: 1.0
+    
     # Ramp rate constraints to prevent rapid cycling (fraction of p_nom per hour)
     # Default: 0.5 means link dispatch can change by max 50% of capacity per hour
-    # Technology-specific values override the default (format: "profile|technology": value)
+    # Technology-specific values override the default
     ramp_rate:
       default: 0.5  # 50% per hour (prevents rapid charge/discharge switching)
+      # Technology-specific ramp rates (optional)
+      # "Iron & steel industry|Scrap-EAF": 0.3  # 30% per hour for EAF
+      # "Iron & steel industry|H2-DRI-EAF": 0.2  # 20% per hour for DRI (slower due to H2 storage)
 
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#costs
@@ -1037,7 +1086,7 @@ clustering:
       ramp_limit_down: max
   temporal:
     resolution_elec: false
-    resolution_sector: false
+    resolution_sector: 6h
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#adjustments
 adjustments:
@@ -1190,16 +1239,6 @@ data:
     source: archive
     version: latest
 
-# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#overpass_api
-overpass_api:
-  url: https://overpass-api.de/api/interpreter
-  max_tries: 5
-  timeout: 600
-  user_agent:
-    project_name: PyPSA-Eur
-    email: contact@pypsa.org
-    website: https://github.com/PyPSA/pypsa-eur
-
 secrets:
   corine: '' #Add API key here if primary source is used for retrieving corine dataset after registering in https://land.copernicus.eu/user/login
 
@@ -1222,6 +1261,7 @@ solving:
     transmission_losses: 2
     linearized_unit_commitment: true
     horizon: 365
+    nhours: 168  # Limit to first 168 hours (1 week) for testing
     post_discretization:
       enable: false
       line_unit_size: 1700
@@ -1252,8 +1292,8 @@ solving:
     SAFE: false
 
   solver:
-    name: gurobi
-    options: gurobi-default
+    name: highs
+    options: highs-default
 
   solver_options:
     highs-default:

--- a/doc/configtables/industry.csv
+++ b/doc/configtables/industry.csv
@@ -21,7 +21,7 @@ waste_to_energy,--,bool,Switch to enable expansion of waste to energy CHPs for c
 waste_to_energy_cc,--,bool,Switch to enable expansion of waste to energy CHPs for conversion of plastics with carbon capture. Default is false.
 ,,,
 sector_ratios_fraction_future,--,Dictionary with planning horizons as keys.,The fraction of total progress in fuel and process switching achieved in the industry sector.
-basic_chemicals_without_NH3_production_today,Mt/a,float,"The amount of basic chemicals produced without ammonia (= 86 Mtethylene-equiv - 17 MtNH3)."
+basic_chemicals_without_NH3_production_today,Mt/a,float,The amount of basic chemicals produced without ammonia (= 86 Mtethylene-equiv - 17 MtNH3).
 HVC_production_today,MtHVC/a,float,"The amount of high value chemicals (HVC) produced. This includes ethylene, propylene and BTX. From `DECHEMA (2017) <https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry-p-20002750.pdf>`_, Figure 16, page 107"
 Mwh_elec_per_tHVC _mechanical_recycling,MWh/tHVC,float,"The energy amount of electricity needed to produce a ton of high value chemical (HVC) using mechanical recycling. From SI of `Meys et al (2020) <https://doi.org/10.1016/j.resconrec.2020.105010>`_, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756."
 Mwh_elec_per_tHVC _chemical_recycling,MWh/tHVC,float,"The energy amount of electricity needed to produce a ton of high value chemical (HVC) using chemical recycling. The default value is based on pyrolysis and electric steam cracking. From `Material Economics (2019) <https://materialeconomics.com/latest-updates/industrial-transformation-2050>`_, page 125"
@@ -35,4 +35,5 @@ MWh_CH4_per_tMeOH,MWhCH4/tMeOH,float,"The energy amount of methane needed to pro
 MWh_MeOH_per_tMeOH,LHV,float,"The energy amount per ton of methanol. From `DECHEMA (2017) <https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry-p-20002750.pdf>`_, page 74."
 hotmaps_locate_missing,--,"{true,false}",Locate industrial sites without valid locations based on city and countries.
 reference_year,year,YYYY,The year used as the baseline for industrial energy demand and production. Data extracted from `JRC-IDEES 2015 <https://data.jrc.ec.europa.eu/dataset/jrc-10110-10001>`_
-oil_refining_emissions,tCO2/MWh,float,"The emissions from oil fuel processing (e.g. oil in petrochemical refinieries). The default value of 0.013 tCO2/MWh is based on DE statistics for 2019; the EU value is very similar."
+oil_refining_emissions,tCO2/MWh,float,The emissions from oil fuel processing (e.g. oil in petrochemical refinieries). The default value of 0.013 tCO2/MWh is based on DE statistics for 2019; the EU value is very similar.
+temporal_electricity_industry_load,--,"{true,false}",Switch to enable the use of temporally resolved electricity industry load profiles from `FfE (Forschungsstelle für Energiewirtschaft) 2021 <https://github.com/PyPSA/pypsa-eur/pull/1875>`_. Data is for Germany which is projected to the rest of Europe for the same industries. Default is true.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,22 @@ Release Notes
 Upcoming Release
 ================
 
+* Fix compatibility of rules `build_gas_input_locations` and `build_gas_network` with pyogrio >=0.12.0 (https://github.com/PyPSA/pypsa-eur/pull/1955).
+
+* Added interactive (html) balance maps `results/maps/interactive/` (https://github.com/PyPSA/pypsa-eur/pull/1935) based on https://docs.pypsa.org/latest/user-guide/plotting/explore/. Settings for interactive maps can be found in `plotting.default.yaml` under `plotting["balance_map_interactive"]`.
+
+* Relocated and modified static (pdf) balance maps to `results/maps/static/` (https://github.com/PyPSA/pypsa-eur/pull/1935) for better organization. 
+
+* With https://github.com/PyPSA/pypsa-eur/pull/1935, note that bus carriers for balance maps containing spaces need to be specified with underscores `_` in the configuration file, e.g., `co2_stored` instead of `co2 stored`. This is to ensure compatibility with queue managers like slurm. 
+
+* Fix building osm network using overpass API (https://github.com/PyPSA/pypsa-eur/pull/1940).
+
+* Added configuration option to set overpass API URL, maximum retries, timeout and user agent information (https://github.com/PyPSA/pypsa-eur/pull/1940 and https://pypsa-eur.readthedocs.io/en/latest/configuration.html#overpass_api). For a list of public overpass APIs see `here <https://wiki.openstreetmap.org/wiki/Overpass_API#Public_Overpass_API_instances>`_.
+
+* Refactored `solve_network.py` and `solve_operations_network.py` to separate optimization problem preparation from solving, enabling inspection of optimization problems before solve execution. 
+
+* Added example configurations for rolling horizon and iterative optimization modes in `config/examples/`.
+
 * Added existing biomass decentral/rural residential and services heating capacity.
 
 * Fix parsing in Swiss passenger cars data (https://github.com/PyPSA/pypsa-eur/pull/1934 and https://github.com/PyPSA/pypsa-eur/pull/1936).
@@ -118,6 +134,8 @@ Upcoming Release
   The ``purge`` rule now removes their contents but keeps the folders (https://github.com/PyPSA/pypsa-eur/pull/1764).
 
 * Misc: Automatically update the DAGs shown in the documentation (https://github.com/PyPSA/pypsa-eur/pull/1880).
+
+* Add configurable **industry electricity demand-side response (DSR)** based on virtual ``Store`` components with time-varying energy bounds per FfE profile. New configuration keys under ``industry: dsr:`` allow setting flexibility fractions, shift hours, checkpoint hours (``restriction_time``) and a global ``restriction_value``; a dedicated build step (``build_industry_dsr_profile``) creates an hourly checkpoint profile that is applied in ``prepare_sector_network.py`` as time-varying ``e_max_pu``/``e_min_pu`` for industry DSR stores, with bus mapping aligned to low-voltage industry loads.
 
 PyPSA-Eur v2025.07.0 (11th July 2025)
 =====================================

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1093,6 +1093,9 @@ rule build_industrial_production_per_node:
 
 
 rule build_industrial_energy_demand_per_node:
+    params:
+        snapshots=config_provider("snapshots"),
+        drop_leap_day=config_provider("enable", "drop_leap_day"),
     input:
         industry_sector_ratios=resources(
             "industry_sector_ratios_{planning_horizons}.csv"
@@ -1103,9 +1106,17 @@ rule build_industrial_energy_demand_per_node:
         industrial_energy_demand_per_node_today=resources(
             "industrial_energy_demand_today_base_s_{clusters}.csv"
         ),
+        ffe_profiles="data/ffe_industry_load_profiles.json",
+        
     output:
         industrial_energy_demand_per_node=resources(
             "industrial_energy_demand_base_s_{clusters}_{planning_horizons}.csv"
+        ),
+        industrial_electricity_demand_per_node_temporal=resources(
+            "industrial_electricity_demand_temporal_base_s_{clusters}_{planning_horizons}.csv"
+        ),
+        industrial_electricity_demand_per_profile_temporal=resources(
+            "industrial_electricity_demand_per_profile_temporal_base_s_{clusters}_{planning_horizons}.csv"
         ),
     threads: 1
     resources:
@@ -1122,6 +1133,29 @@ rule build_industrial_energy_demand_per_node:
         )
     script:
         "../scripts/build_industrial_energy_demand_per_node.py"
+
+
+rule build_industry_dsr_profile:
+    params:
+        restriction_time=config_provider("industry", "dsr", "restriction_time"),
+        technology_breakdown=config_provider("industry", "dsr", "technology_breakdown", default={}),
+    input:
+        industrial_electricity_demand_per_profile_temporal=resources(
+            "industrial_electricity_demand_per_profile_temporal_base_s_{clusters}_{planning_horizons}.csv"
+        ),
+    output:
+        industrial_dsr_profile=resources(
+            "industrial_dsr_profile_base_s_{clusters}_{planning_horizons}.csv"
+        ),
+    threads: 1
+    resources:
+        mem_mb=500,
+    log:
+        logs("build_industry_dsr_profile_{clusters}_{planning_horizons}.log"),
+    benchmark:
+        benchmarks("build_industry_dsr_profile/s_{clusters}_{planning_horizons}")
+    script:
+        "../scripts/build_industry_dsr_profile.py"
 
 
 rule build_industrial_energy_demand_per_country_today:
@@ -1538,6 +1572,24 @@ rule prepare_sector_network:
         clustered_pop_layout=resources("pop_layout_base_s_{clusters}.csv"),
         industrial_demand=resources(
             "industrial_energy_demand_base_s_{clusters}_{planning_horizons}.csv"
+        ),
+        industrial_electricity_profiles=resources(
+            "industrial_electricity_demand_temporal_base_s_{clusters}_{planning_horizons}.csv"
+        ),
+        industrial_electricity_profiles_per_profile=lambda w: (
+            resources(
+                "industrial_electricity_demand_per_profile_temporal_base_s_{clusters}_{planning_horizons}.csv"
+            )
+            if config_provider("industry", "temporal_electricity_industry_load")(w)
+            and config_provider("industry", "dsr", "enable")(w)
+            else []
+        ),
+        industrial_dsr_profile=lambda w: (
+            resources(
+                "industrial_dsr_profile_base_s_{clusters}_{planning_horizons}.csv"
+            )
+            if config_provider("industry", "dsr", "enable")(w)
+            else []
         ),
         hourly_heat_demand_total=resources(
             "hourly_heat_demand_total_base_s_{clusters}.nc"

--- a/scripts/build_industrial_energy_demand_per_node.py
+++ b/scripts/build_industrial_energy_demand_per_node.py
@@ -22,14 +22,336 @@ For each bus, the following carriers are considered:
 
 which can later be used as values for the industry load.
 """
+import requests
+
+from datetime import datetime
+
 
 import logging
 
+import numpy as np
 import pandas as pd
+import json
+import holidays
 
-from scripts._helpers import configure_logging, set_scenario_config
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    set_scenario_config,
+
+)
 
 logger = logging.getLogger(__name__)
+
+# Industry category to FfE profile mapping (updated to match correct profile names)
+
+INDUSTRY_CATEGORY_TO_PROFILE = {
+    "Electric arc": "Iron & steel industry",
+    "DRI + Electric arc": "Iron & steel industry",
+    "Integrated steelworks": "Iron & steel industry",
+    "HVC": "Non-specified (Industry)",
+    "HVC (mechanical recycling)": "Non-specified (Industry)",
+    "HVC (chemical recycling)": "Non-specified (Industry)",
+    "Ammonia": "Non-specified (Industry)",
+    "Chlorine": "Non-specified (Industry)",
+    "Methanol": "Non-specified (Industry)",
+    "Other chemicals": "Non-specified (Industry)",
+    "Pharmaceutical products etc.": "Non-specified (Industry)",
+    "Cement": "Non-metallic Minerals",
+    "Ceramics & other NMM": "Non-metallic Minerals",
+    "Glass production": "Non-metallic Minerals",
+    "Pulp production": "Paper, Pulp and Print",
+    "Paper production": "Paper, Pulp and Print",
+    "Printing and media reproduction": "Paper, Pulp and Print",
+    "Food, beverages and tobacco": "Food and Tobacco",
+    "Alumina production": "Iron & steel industry",
+    "Aluminium - primary production": "Iron & steel industry",
+    "Aluminium - secondary production": "Iron & steel industry",
+    "Other non-ferrous metals": "Non-specified (Industry)",
+    "Transport equipment": "Transport Equipment",
+    "Machinery equipment": "Machinery",
+    "Textiles and leather": "Textile and Leather",
+    "Wood and wood products": "Wood and Wood Products",
+    "Other industrial sectors": "Non-specified (Industry)",
+
+    }
+
+
+def load_ffe_load_profiles(json_file):
+    """Load normalized industry load profiles from FfE JSON file."""
+
+    # Load pre-downloaded JSON data
+    with open(json_file, "r") as f:
+        data = json.load(f)
+
+    logger.info(f"Loaded FfE data: {data['title']}")
+
+       # Map internal_id to profile names (internal_id [2,3] missing from json file, reported back to FfE)
+    id_to_profile = {
+       # 0: "Industry (total)", # missing
+        1: "Iron & steel industry",
+        4: "Non-metallic Minerals",
+        5: "Transport Equipment",
+        6: "Machinery",
+        7: "Mining and Quarrying",
+        8: "Food and Tobacco",
+        9: "Paper, Pulp and Print",
+        10: "Wood and Wood Products",
+        11: "Construction",
+        12: "Textile and Leather",
+        13: "Non-specified (Industry)",
+
+    }
+
+    # Create hourly timestamps for 2017
+    timestamps = pd.date_range("2017-01-01", "2017-12-31 23:00:00", freq="h")
+
+    # Parse the data into a DataFrame
+    df = pd.json_normalize(data["data"])
+    df = df.set_index(df["internal_id"].map(lambda x: x[0]))["values"]
+    profiles_df = (
+        pd.DataFrame(np.vstack(df), index=df.index, columns=timestamps)
+        .rename(index=id_to_profile)
+        .T
+
+    )
+    logger.info(f"Loaded profiles: {list(profiles_df.columns)}")
+
+    return profiles_df
+
+def create_nodal_electricity_profiles(
+        nodal_df, nodal_sector_df, snapshots, ffe_profiles,       
+):
+    """Create hourly electricity demand profiles for each node."""
+
+    # ---- Vectorised combination of sector profiles per node ----
+    # Extract electricity sector demands for all nodes at once:
+    # nodal_sector_df.loc["elec"] returns Series with MultiIndex (node, sector)
+    # Unstack to get DataFrame with index=sectors, columns=nodes
+    elec_demands_series = nodal_sector_df.loc["elec"]
+    elec_demands = elec_demands_series.unstack(level=0)  # index=sectors, columns=nodes
+
+    # Map each sector to the corresponding FfE profile name
+    sector_to_profile = pd.Series(INDUSTRY_CATEGORY_TO_PROFILE)
+    sector_to_profile = sector_to_profile.reindex(elec_demands.index)
+
+    if sector_to_profile.isna().any():
+        missing = sector_to_profile[sector_to_profile.isna()].index.tolist()
+        raise KeyError(
+            f"Missing FfE profile mapping for industrial sectors: {missing}"
+        )
+
+    # Aggregate sector demands to profile-level demands:
+    #   index  -> FfE profile name
+    #   columns -> nodes
+    profile_demands = elec_demands.groupby(sector_to_profile).sum()
+
+    # Ensure all required profiles exist in the FfE data
+    missing_profiles = set(profile_demands.index) - set(ffe_profiles.columns)
+    if missing_profiles:
+        raise ValueError(
+            f"Profiles {missing_profiles} from INDUSTRY_CATEGORY_TO_PROFILE not in FfE data"
+        )
+
+    # Compute 2017 reference profiles for all nodes in one matrix multiplication:
+    #   ffe_profiles[profiles] : (hours x profiles)
+    #   profile_demands        : (profiles x nodes)
+    #   -> weighted_profiles   : (hours x nodes)
+    weighted_profiles = ffe_profiles[profile_demands.index].dot(profile_demands)
+
+    # ---- Per-node calendar mapping and checks (cannot easily be vectorised) ----
+    # Create node-to-country mapping (instead of inferring from node name string)
+    # Note: Currently derived from node name prefix, but structured as mapping
+    # for easier replacement if proper country data becomes available
+    node_to_country = pd.Series(nodal_df.index.str[:2], index=nodal_df.index)
+    
+    nodal_profiles = pd.DataFrame(index=snapshots, columns=nodal_df.index, dtype=float)
+
+    for node in nodal_df.index:
+        # Get electricity demand by sector for this node (TWh/a)
+        sector_demands = elec_demands[node]
+
+        # Check if sum of sector demands matches total demand
+        assert np.isclose(
+            sector_demands.sum(), nodal_df.loc[node, "electricity"], rtol=1e-5
+        ), f"Sum of sector demands does not match total demand for node {node}. \n"
+
+        # Node-specific 2017 reference profile (already sector-weighted)
+        node_profile = weighted_profiles[node]
+
+        # Map profile to snapshots with correct day-of-week alignment
+        hourly_profile = map_profile_to_snapshots(
+            node_profile,
+            snapshots,
+            node_country=node_to_country[node],
+            tol=0.02,  # Tolerance increased to 2% for holiday replacement and date adjustment
+        )
+
+        # Save in MW
+        nodal_profiles[node] = hourly_profile * 1e6
+    
+    # Check that hourly profiles match annual demand
+    assert np.allclose(
+        nodal_profiles.sum() / 1e6, nodal_df["electricity"], rtol=1e-5
+    ), (
+        f"Hourly profiles do not match annual demand. \nMax difference: {(nodal_profiles.sum() / 1e6 - nodal_df['electricity']).abs().max():.6f} TWh"
+    )
+    logger.info("Hourly profiles verified to match annual demand")
+
+    return nodal_profiles
+
+
+def create_nodal_electricity_profiles_per_profile(
+    nodal_df, nodal_sector_df, snapshots, ffe_profiles, node_to_country
+):
+    """
+    Create hourly electricity demand per FfE profile per node (MW).
+
+    Returns a DataFrame with MultiIndex columns (node, profile) and index = snapshots.
+    Used for industry DSR (Option B): one Store per profile per node.
+    """
+    elec_demands_series = nodal_sector_df.loc["elec"]
+    elec_demands = elec_demands_series.unstack(level=0)
+
+    sector_to_profile = pd.Series(INDUSTRY_CATEGORY_TO_PROFILE)
+    sector_to_profile = sector_to_profile.reindex(elec_demands.index)
+    if sector_to_profile.isna().any():
+        missing = sector_to_profile[sector_to_profile.isna()].index.tolist()
+        raise KeyError(
+            f"Missing FfE profile mapping for industrial sectors: {missing}"
+        )
+
+    profile_demands = elec_demands.groupby(sector_to_profile).sum()
+    missing_profiles = set(profile_demands.index) - set(ffe_profiles.columns)
+    if missing_profiles:
+        raise ValueError(
+            f"Profiles {missing_profiles} from INDUSTRY_CATEGORY_TO_PROFILE not in FfE data"
+        )
+
+    profiles = profile_demands.index.tolist()
+    nodes = nodal_df.index.tolist()
+
+    # Build (snapshots x (node, profile)) in MW
+    data = {}
+    for node in nodes:
+        for profile in profiles:
+            annual_twh = profile_demands.loc[profile, node]
+            if annual_twh <= 0:
+                # Zero demand: skip map_profile_to_snapshots (avoids 0/0 -> NaN in scaling)
+                data[(node, profile)] = pd.Series(0.0, index=snapshots)
+            else:
+                ref_profile = ffe_profiles[profile] * annual_twh
+                mapped = map_profile_to_snapshots(
+                    ref_profile,
+                    snapshots,
+                    node_country=node_to_country[node],
+                    tol=0.02,
+                )
+                data[(node, profile)] = mapped * 1e6
+    per_profile = pd.DataFrame(data, index=snapshots)
+    per_profile.columns.names = ["node", "profile"]
+    return per_profile
+
+
+def map_profile_to_snapshots(reference_profile, snapshots, node_country='DE', tol=0.02):
+    """
+    Map 2017 German reference profile to target snapshots by weekday rotation.
+
+    Process:
+    1. Remove German holidays from 2017 reference (replace with weekday-hour avg)
+    2. Rotate and map to target year
+    3. Replace target country's holidays with Sunday-hour averages (if available)
+    4. Drop leap day if needed (handled at the end)
+    5. Scale once at the end
+    """
+    SOURCE_YEAR = 2017
+    TARGET_YEAR = snapshots[0].year
+    
+    # Work with a copy of the reference profile
+    s = reference_profile.copy()
+    original_energy = s.sum()
+    
+    # STEP 1: Compute average day profiles
+    average_days = s.groupby([s.index.dayofweek, s.index.hour]).mean()
+    
+    # STEP 2: Normalize German holidays in source year
+    de_holidays = holidays.country_holidays('DE', years=SOURCE_YEAR)
+    holiday_dates_de = pd.to_datetime(list(de_holidays.keys()))
+    is_holiday = s.index.normalize().isin(holiday_dates_de)
+    
+    if is_holiday.any():
+        s.loc[is_holiday] = (
+            s.loc[is_holiday]
+            .index.map(lambda i: average_days.loc[(i.dayofweek, i.hour)])
+            .to_numpy()
+        )
+    
+    # STEP 3: Add day drift (weekday alignment)
+    day_drift = (
+        pd.Timestamp(SOURCE_YEAR, 1, 1).dayofweek
+        - pd.Timestamp(TARGET_YEAR, 1, 1).dayofweek
+    )
+    
+    ts = s.shift(day_drift, freq="D")
+    ts.index = ts.index.map(lambda t: t.replace(year=TARGET_YEAR))
+    ts.sort_index(inplace=True)
+    
+    # STEP 4: Handle leap year
+    if pd.Timestamp(TARGET_YEAR, 1, 1).is_leap_year:
+        # Shift dates from March onward back by 1 day to account for leap year
+        mask = ts.index.month >= 3
+        ts.index = pd.DatetimeIndex(
+            np.where(mask, ts.index - pd.Timedelta(days=1), ts.index)
+        )
+        
+        # Add extra day (Dec 31) for leap year
+        extra_day_i = pd.date_range(f"{TARGET_YEAR}-12-31", periods=24, freq="h")
+        # Get average profile for the weekday of Dec 31
+        weekday_dec31 = extra_day_i[0].dayofweek
+        extra_day_values = [average_days.loc[(weekday_dec31, hour)] for hour in range(24)]
+        extra_day = pd.Series(extra_day_values, index=extra_day_i)
+        ts = pd.concat([ts, extra_day]).sort_index()
+    
+    # STEP 5: Impose target country holidays
+    try:
+        target_holidays = holidays.country_holidays(node_country, years=TARGET_YEAR)
+        target_holiday_dates = pd.to_datetime(list(target_holidays.keys()))
+        is_holiday = ts.index.normalize().isin(target_holiday_dates)
+        
+        if is_holiday.any():
+            ts.loc[is_holiday] = (
+                ts.loc[is_holiday].index.map(lambda i: average_days.loc[(6, i.hour)]).to_numpy()
+            )
+    except NotImplementedError:
+        logger.warning(f"Country '{node_country}' not available in holidays library - skipping holiday replacement")
+    
+    # STEP 6: Drop leap day if needed (snapshots already have it dropped)
+    drop_leap_day = not any((snapshots.month == 2) & (snapshots.day == 29))
+    if drop_leap_day and ts.index.is_leap_year.any():
+        ts = ts[~((ts.index.month == 2) & (ts.index.day == 29))]
+    
+    # STEP 7: Map to snapshots (reindex to match exact snapshot timestamps)
+    mapped = ts.reindex(snapshots)
+    
+    # Fill any missing values (shouldn't happen, but safety fallback)
+    if mapped.isna().any():
+        missing = mapped.isna()
+        mapped.loc[missing] = (
+            mapped.loc[missing].index.map(lambda i: average_days.loc[(i.dayofweek, i.hour)]).to_numpy()
+        )
+    
+    # STEP 8: Scale to preserve energy (with tolerance check)
+    mapped_sum = mapped.sum()
+    if original_energy == 0 or np.isnan(original_energy) or mapped_sum == 0 or np.isnan(mapped_sum):
+        # Avoid 0/0 or nan/... leading to NaN scaling_factor and assertion failure
+        return pd.Series(0.0, index=snapshots)
+    scaling_factor = original_energy / mapped_sum
+    assert abs(scaling_factor - 1.0) < tol, (
+        f"Energy deviation after mapping: {(scaling_factor - 1.0) * 100:.2f}%"
+    )
+    return mapped * scaling_factor
+
+
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
@@ -37,13 +359,14 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "build_industrial_energy_demand_per_node",
-            clusters=48,
+            clusters=50,
             planning_horizons=2030,
+            run="temporal_industry_load"
         )
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 
-    # import ratios
+    # load industry sector ratios
     fn = snakemake.input.industry_sector_ratios
     sector_ratios = pd.read_csv(fn, header=[0, 1], index_col=0)
 
@@ -55,8 +378,11 @@ if __name__ == "__main__":
     fn = snakemake.input.industrial_energy_demand_per_node_today
     nodal_today = pd.read_csv(fn, index_col=0)
 
+    # Create node-to-country mapping (instead of inferring from node name string)
+    node_to_country = pd.Series(nodal_production.index.str[:2], index=nodal_production.index)
+    
     nodal_sector_ratios = pd.concat(
-        {node: sector_ratios[node[:2]] for node in nodal_production.index}, axis=1
+        {node: sector_ratios[node_to_country[node]] for node in nodal_production.index}, axis=1
     )
 
     nodal_production_stacked = nodal_production.stack()
@@ -80,5 +406,41 @@ if __name__ == "__main__":
 
     nodal_df.index.name = "TWh/a (MtCO2/a)"
 
+    # Export annual demand
+
     fn = snakemake.output.industrial_energy_demand_per_node
-    nodal_df.to_csv(fn, float_format="%.2f")
+    nodal_df.to_csv(fn)
+
+    #Generate hourly electricity profiles
+
+    # final energy consumption per node and industry and industry sector (profiles) (TWh/a)
+    nodal_sector_df = nodal_sector_ratios.multiply(nodal_production_stacked)
+
+    logger.info("Creating hourly industry electricity demand profiles...")
+    snapshots = get_snapshots(
+        snakemake.params.snapshots, snakemake.params.drop_leap_day
+    )
+
+    logger.info("Loading FfE industry load profiles...")
+    ffe_profiles = load_ffe_load_profiles(snakemake.input.ffe_profiles)
+
+
+    nodal_electricity_profiles = create_nodal_electricity_profiles(
+        nodal_df, nodal_sector_df, snapshots, ffe_profiles
+    )
+
+    # Export hourly profiles (total per node)
+    fn_profiles = snakemake.output.industrial_electricity_demand_per_node_temporal
+    nodal_electricity_profiles.to_csv(fn_profiles, float_format="%.2f")
+    logger.info(f"Hourly electricity profiles saved to {fn_profiles}")
+
+    # Export hourly profiles per FfE profile per node (for industry DSR Option B)
+    per_profile = create_nodal_electricity_profiles_per_profile(
+        nodal_df, nodal_sector_df, snapshots, ffe_profiles, node_to_country
+    )
+    fn_per_profile = snakemake.output.industrial_electricity_demand_per_profile_temporal
+    per_profile_flat = per_profile.copy()
+    per_profile_flat.columns = [f"{n}|{p}" for n, p in per_profile.columns]
+    per_profile_flat.to_csv(fn_per_profile, float_format="%.2f")
+    logger.info(f"Hourly electricity profiles per profile saved to {fn_per_profile}")
+

--- a/scripts/build_industry_dsr_profile.py
+++ b/scripts/build_industry_dsr_profile.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: MIT
+"""
+Build industry DSR checkpoint profile per FfE profile.
+
+Produces a time series (snapshots x FfE profiles) with value 0 at checkpoint hours
+and 1.0 elsewhere. Used as e_max_pu / e_min_pu for industry DSR Stores so that
+demand is balanced within each period between checkpoints (like residential heat DSM).
+Different sectors (FfE profiles) can have different restriction_time (operating hours).
+"""
+
+import logging
+
+import pandas as pd
+
+from scripts._helpers import configure_logging, set_scenario_config
+
+logger = logging.getLogger(__name__)
+
+
+def build_industry_dsr_profile(snapshots, restriction_time):
+    """
+    Build DSR checkpoint profile per FfE profile (snapshots x profiles).
+
+    At checkpoint hours for each profile, value is 0 (store must be empty);
+    elsewhere value is 1.0. restriction_value is applied in prepare_sector_network.
+    Hour of day is taken from snapshots (UTC).
+
+    Parameters
+    ----------
+    snapshots : pd.DatetimeIndex
+        Time index (e.g. n.snapshots).
+    restriction_time : dict
+        Keys = FfE profile names, values = list of hours (0-23) at which store must be empty.
+
+    Returns
+    -------
+    pd.DataFrame
+        Index = snapshots, columns = profile names, values in {0, 1}.
+    """
+    profiles = list(restriction_time.keys())
+    out = pd.DataFrame(index=snapshots, columns=profiles, dtype=float)
+    for profile in profiles:
+        hours_check = restriction_time.get(profile, [])
+        out[profile] = 1.0
+        if hours_check:
+            mask = out.index.hour.isin(hours_check)
+            out.loc[mask, profile] = 0.0
+    return out
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+
+        snakemake = mock_snakemake(
+            "build_industry_dsr_profile",
+            clusters=50,
+            planning_horizons=2030,
+        )
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+
+    # Get snapshots and profile names from per-profile temporal demand file
+    path = snakemake.input.industrial_electricity_demand_per_profile_temporal
+    if isinstance(path, list):
+        path = path[0]
+    per_profile = pd.read_csv(path, index_col=0, parse_dates=True)
+    snapshots = per_profile.index
+    # Unique FfE profile names from columns "node|profile"
+    profiles = sorted({c.split("|", 1)[1] for c in per_profile.columns})
+
+    restriction_time = snakemake.params.restriction_time or {}
+    technology_breakdown = snakemake.params.get("technology_breakdown", {})
+
+    # Check if technology breakdown is provided
+    use_technology_breakdown = bool(technology_breakdown)
+    
+    if use_technology_breakdown:
+        # Technology-specific: build profiles for "profile|technology" keys
+        logger.info("Building technology-specific DSR profiles")
+        
+        # Collect all technology keys from restriction_time
+        tech_keys = set()
+        profile_keys = set()
+        
+        for key in restriction_time.keys():
+            if "|" in key:
+                # Technology-specific key: "profile|technology"
+                tech_keys.add(key)
+                profile_part = key.split("|", 1)[0]
+                profile_keys.add(profile_part)
+            else:
+                # Profile-level key
+                profile_keys.add(key)
+        
+        # Build profiles for technology-specific keys
+        tech_restriction_time = {k: restriction_time[k] for k in tech_keys if k in restriction_time}
+        profile_restriction_time = {k: restriction_time[k] for k in profile_keys if k in restriction_time and k not in tech_keys}
+        
+        # Build technology-specific profiles
+        all_columns = list(tech_keys) + list(profile_keys)
+        dsr_profile = pd.DataFrame(index=snapshots, columns=all_columns, dtype=float)
+        
+        # Fill technology-specific columns
+        for tech_key in tech_keys:
+            hours_check = restriction_time.get(tech_key, [])
+            dsr_profile[tech_key] = 1.0
+            if hours_check:
+                mask = dsr_profile.index.hour.isin(hours_check)
+                dsr_profile.loc[mask, tech_key] = 0.0
+        
+        # Fill profile-level columns (for profiles without technology breakdown)
+        for profile in profile_keys:
+            if profile in tech_keys:
+                continue  # Already handled as technology-specific
+            hours_check = restriction_time.get(profile, [])
+            dsr_profile[profile] = 1.0
+            if hours_check:
+                mask = dsr_profile.index.hour.isin(hours_check)
+                dsr_profile.loc[mask, profile] = 0.0
+        
+        # Ensure all profiles present in data have a column (fill missing with 1.0)
+        for p in profiles:
+            if p not in dsr_profile.columns:
+                dsr_profile[p] = 1.0
+    else:
+        # No technology_breakdown: build profile-level profiles (may not be used if no DSR stores are created)
+        logger.info("Building profile-level DSR profiles (technology_breakdown not provided)")
+        # Restrict to profiles present in the data
+        restriction_time = {p: restriction_time[p] for p in profiles if p in restriction_time}
+        if not restriction_time:
+            logger.warning("No restriction_time keys match profile names; using all 1.0 profile.")
+            dsr_profile = pd.DataFrame(1.0, index=snapshots, columns=profiles)
+        else:
+            dsr_profile = build_industry_dsr_profile(snapshots, restriction_time)
+            # Ensure all profiles present in data have a column (fill missing with 1.0)
+            for p in profiles:
+                if p not in dsr_profile.columns:
+                    dsr_profile[p] = 1.0
+
+    dsr_profile.to_csv(snakemake.output.industrial_dsr_profile, float_format="%.4f")
+    logger.info(f"Industry DSR profile saved to {snakemake.output.industrial_dsr_profile}")

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1007,9 +1007,9 @@ def add_biomass_to_methanol(n, costs):
         + costs.at["biomass-to-methanol", "CO2 stored"],
         p_nom_extendable=True,
         capital_cost=costs.at["biomass-to-methanol", "capital_cost"]
-        / costs.at["biomass-to-methanol", "efficiency"],
+        * costs.at["biomass-to-methanol", "efficiency"],
         marginal_cost=costs.loc["biomass-to-methanol", "VOM"]
-        / costs.at["biomass-to-methanol", "efficiency"],
+        * costs.at["biomass-to-methanol", "efficiency"],
     )
 
 
@@ -1032,11 +1032,11 @@ def add_biomass_to_methanol_cc(n, costs):
         * costs.at["biomass-to-methanol", "capture rate"],
         p_nom_extendable=True,
         capital_cost=costs.at["biomass-to-methanol", "capital_cost"]
-        / costs.at["biomass-to-methanol", "efficiency"]
+        * costs.at["biomass-to-methanol", "efficiency"]
         + costs.at["biomass CHP capture", "capital_cost"]
         * costs.at["biomass-to-methanol", "CO2 stored"],
         marginal_cost=costs.loc["biomass-to-methanol", "VOM"]
-        / costs.at["biomass-to-methanol", "efficiency"],
+        * costs.at["biomass-to-methanol", "efficiency"],
     )
 
 
@@ -1583,6 +1583,26 @@ def insert_electricity_distribution_grid(
     # "agriculture machinery electric" and "agriculture electricity"
     loads = n.loads.index[n.loads.carrier.str.contains("electric")]
     n.loads.loc[loads, "bus"] += " low voltage"
+
+    # Move industry DSR components to low voltage buses
+    # 1. Move stores (on flexibility buses) - flexibility buses stay as-is
+    # 2. Move charge/discharge links' bus0/bus1 to low voltage
+    industry_dsr_stores = n.stores.index[n.stores.carrier == "industry dsr"]
+    if len(industry_dsr_stores) > 0:
+        # Stores are on flexibility buses, which don't need "low voltage" suffix
+        # But we need to update the links' buses
+        industry_dsr_charge_links = n.links.index[n.links.carrier == "industry dsr charge"]
+        industry_dsr_discharge_links = n.links.index[n.links.carrier == "industry dsr discharge"]
+        
+        # Charge links: bus0 (load bus) needs "low voltage", bus1 (flexibility bus) stays as-is
+        if len(industry_dsr_charge_links) > 0:
+            n.links.loc[industry_dsr_charge_links, "bus0"] += " low voltage"
+        
+        # Discharge links: bus0 (flexibility bus) stays as-is, bus1 (load bus) needs "low voltage"
+        if len(industry_dsr_discharge_links) > 0:
+            n.links.loc[industry_dsr_discharge_links, "bus1"] += " low voltage"
+        
+        logger.info(f"Moved {len(industry_dsr_charge_links)} charge links and {len(industry_dsr_discharge_links)} discharge links to low voltage buses")
 
     bevs = n.links.index[n.links.carrier == "BEV charger"]
     n.links.loc[bevs, "bus0"] += " low voltage"
@@ -4499,6 +4519,7 @@ def add_industry(
     spatial: SimpleNamespace,
     cf_industry: dict,
     investment_year: int,
+    snakemake,
 ):
     """
     Add industry and their corresponding carrier buses to the network.
@@ -5003,14 +5024,437 @@ def add_industry(
         )
         n.loads_t.p_set[loads_i] *= factor
 
-    n.add(
-        "Load",
-        nodes,
-        suffix=" industry electricity",
-        bus=nodes,
-        carrier="industry electricity",
-        p_set=industrial_demand.loc[nodes, "electricity"] / nhours,
+    # Check if temporal profiles should be used
+    use_temporal = snakemake.params.industry.get(
+        "temporal_electricity_industry_load", False
     )
+
+    if use_temporal and snakemake.input.industrial_electricity_profiles:
+        logger.info("Using temporal industrial electricity demand profiles")
+
+        # Load hourly profiles (MW)
+        industrial_elec_profiles = pd.read_csv(
+            snakemake.input.industrial_electricity_profiles,
+            index_col=0,
+            parse_dates=True,
+        )
+
+        industrial_loads = industrial_elec_profiles.rename(
+            columns=lambda x: f"{x} industry electricity"
+        )
+
+        # Create a Series with load names as index and bus names as values
+        # This ensures index alignment instead of relying on positional matching
+        bus_series = pd.Series(
+            industrial_elec_profiles.columns.values,
+            index=industrial_loads.columns,
+        )
+
+        n.add(
+            "Load",
+            industrial_loads.columns,
+            bus=bus_series,
+            carrier="industry electricity",
+            p_set=industrial_loads,
+        )
+
+    else:
+        logger.info("Using constant industrial electricity demand")
+        n.add(
+            "Load",
+            nodes,
+            suffix=" industry electricity",
+            bus=nodes,
+            carrier="industry electricity",
+            p_set=industrial_demand.loc[nodes, "electricity"] / nhours,
+        )
+
+    # Industry electricity DSR (Option B): one Store per FfE profile per node
+    # DSR config lives under main config industry.dsr; options["industry"] is sector_opts (bool)
+    industry_config = snakemake.config.get("industry", {})
+    industry_config = industry_config if isinstance(industry_config, dict) else {}
+    dsr_config = industry_config.get("dsr", {})
+    if (
+        use_temporal
+        and dsr_config.get("enable")
+        and getattr(
+            snakemake.input, "industrial_electricity_profiles_per_profile", None
+        )
+    ):
+        per_profile_path = snakemake.input.industrial_electricity_profiles_per_profile
+        path = (
+            per_profile_path[0]
+            if isinstance(per_profile_path, list) and len(per_profile_path) > 0
+            else per_profile_path
+        )
+        if path:
+            logger.info("Adding industry electricity DSR (per-profile Stores)")
+            per_profile_df = pd.read_csv(
+                path, index_col=0, parse_dates=True
+            ).reindex(n.snapshots)
+            # Columns are "node|profile"
+            node_profile = [c.split("|", 1) for c in per_profile_df.columns]
+            nodes_per_profile = {}
+            for n_, p_ in node_profile:
+                nodes_per_profile.setdefault(p_, []).append(n_)
+            flexibility_fraction = dsr_config.get("flexibility_fraction", {})
+            shift_hours = dsr_config.get("shift_hours", {})
+            restriction_value = float(dsr_config.get("restriction_value", 1.0))
+            technology_breakdown = dsr_config.get("technology_breakdown", {})
+            min_load_config = dsr_config.get("min_load", {})  # New: minimum load constraint (fraction of baseline)
+            # Optional DSR checkpoint profile (snapshots x profiles): 0 at checkpoint hours, else restriction_value
+            dsr_profile_df = None
+            dsr_profile_path = getattr(
+                snakemake.input, "industrial_dsr_profile", None
+            )
+            if dsr_profile_path:
+                dsr_path = (
+                    dsr_profile_path[0]
+                    if isinstance(dsr_profile_path, list)
+                    and len(dsr_profile_path) > 0
+                    else dsr_profile_path
+                )
+                if dsr_path:
+                    dsr_profile_df = pd.read_csv(
+                        dsr_path, index_col=0, parse_dates=True
+                    ).reindex(n.snapshots).ffill().bfill()
+            else:
+                logger.warning(
+                    "DSR profile file not found. Using constant constraints (no checkpoints). "
+                    "This means e_cyclic may not enforce periodic balancing correctly."
+                )
+            if "industry dsr" not in n.carriers.index:
+                n.add("Carrier", "industry dsr")
+            
+            # Check if technology breakdown is provided
+            use_technology_breakdown = bool(technology_breakdown)
+            
+            if use_technology_breakdown:
+                # Technology-specific DSR: split profiles by technology
+                logger.info("Using technology-specific industry DSR")
+                logger.info(f"DSR will only be applied to profiles with technology_breakdown: {list(technology_breakdown.keys())}")
+                
+                # Auto-calculate technology shares from production data if needed
+                # Mapping from technology names (in config) to PyPSA sector names (in production data)
+                technology_to_sector = {
+                    # Steel technologies
+                    "Scrap-EAF": "Electric arc",
+                    "H2-DRI-EAF": "DRI + Electric arc",
+                    "BF-BOF-CCUS": "Integrated steelworks",
+                    "Manufacturing": None,  # Not a specific sector, will use remaining share
+                    # Aluminium technologies
+                    "Aluminium-primary": "Aluminium - primary production",
+                    "Aluminium-secondary": "Aluminium - secondary production",
+                    "Alumina": "Alumina production",
+                }
+                
+                # Try to auto-calculate shares from production data
+                auto_calc_shares = {}
+                try:
+                    industrial_production_file = getattr(snakemake.input, "industrial_production", None)
+                    if industrial_production_file and os.path.exists(industrial_production_file):
+                        industrial_production = pd.read_csv(industrial_production_file, index_col=0)  # kt/a per node
+                        
+                        # Calculate shares for "Iron & steel industry" profile
+                        if "Iron & steel industry" in technology_breakdown:
+                            profile_tech_shares = technology_breakdown["Iron & steel industry"]
+                            if isinstance(profile_tech_shares, dict):
+                                # Check if any shares need auto-calculation
+                                needs_auto = any(
+                                    v == "auto" or (isinstance(v, str) and v.lower() == "auto")
+                                    for v in profile_tech_shares.values()
+                                )
+                                
+                                if needs_auto:
+                                    logger.info("Auto-calculating technology shares for 'Iron & steel industry' from production data")
+                                    # Get nodes for this profile
+                                    profile_nodes = nodes_per_profile.get("Iron & steel industry", [])
+                                    if profile_nodes:
+                                        # Calculate total production per sector across all nodes
+                                        sector_production = {}
+                                        for tech_name, sector_name in technology_to_sector.items():
+                                            if sector_name and tech_name in profile_tech_shares:
+                                                if sector_name in industrial_production.columns:
+                                                    # Sum production across all nodes (kt/a)
+                                                    sector_production[tech_name] = industrial_production[sector_name].sum()
+                                                else:
+                                                    sector_production[tech_name] = 0.0
+                                        
+                                        # Calculate shares based on production (assuming similar electricity intensity)
+                                        # For more accuracy, we'd need sector ratios, but production is a good proxy
+                                        total_production = sum(sector_production.values())
+                                        if total_production > 0:
+                                            auto_shares = {tech: prod / total_production for tech, prod in sector_production.items()}
+                                            
+                                            # Merge with user-provided shares (user values take precedence)
+                                            final_shares = {}
+                                            for tech, user_share in profile_tech_shares.items():
+                                                if user_share == "auto" or (isinstance(user_share, str) and user_share.lower() == "auto"):
+                                                    final_shares[tech] = auto_shares.get(tech, 0.0)
+                                                    logger.info(f"  Auto-calculated share for '{tech}': {final_shares[tech]:.3f}")
+                                                else:
+                                                    final_shares[tech] = user_share
+                                            
+                                            # Handle "Manufacturing" or other technologies not in production data
+                                            # Distribute remaining share proportionally
+                                            remaining_techs = [t for t in profile_tech_shares.keys() if t not in technology_to_sector or technology_to_sector[t] is None]
+                                            if remaining_techs:
+                                                remaining_share = 1.0 - sum(v for k, v in final_shares.items() if k not in remaining_techs)
+                                                if remaining_share > 0:
+                                                    for tech in remaining_techs:
+                                                        if tech in profile_tech_shares and (profile_tech_shares[tech] == "auto" or (isinstance(profile_tech_shares[tech], str) and profile_tech_shares[tech].lower() == "auto")):
+                                                            # Distribute remaining share equally (or use user-provided if not auto)
+                                                            final_shares[tech] = remaining_share / len(remaining_techs)
+                                                        elif tech in profile_tech_shares:
+                                                            final_shares[tech] = profile_tech_shares[tech]
+                                            
+                                            auto_calc_shares["Iron & steel industry"] = final_shares
+                                            logger.info(f"Auto-calculated technology shares for 'Iron & steel industry': {final_shares}")
+                except Exception as e:
+                    logger.warning(f"Could not auto-calculate technology shares from production data: {e}")
+                    logger.warning("Falling back to user-provided shares")
+                
+                for profile in nodes_per_profile.keys():
+                    if profile not in technology_breakdown:
+                        # Profile without technology breakdown: skip (no DSR for this profile)
+                        logger.debug(f"Profile '{profile}' has no technology breakdown, skipping DSR")
+                        continue
+                    
+                    # Get technology shares for this profile (use auto-calculated if available)
+                    if profile in auto_calc_shares:
+                        tech_shares = auto_calc_shares[profile]
+                    else:
+                        tech_shares = technology_breakdown[profile]
+                    
+                    if not isinstance(tech_shares, dict):
+                        logger.warning(f"Technology breakdown for '{profile}' is not a dict, skipping")
+                        continue
+                    
+                    # Verify shares sum to ~1.0
+                    total_share = sum(tech_shares.values())
+                    if not np.isclose(total_share, 1.0, rtol=0.01):
+                        logger.warning(
+                            f"Technology shares for '{profile}' sum to {total_share:.3f}, not 1.0. "
+                            f"Normalizing to 1.0."
+                        )
+                        tech_shares = {k: v / total_share for k, v in tech_shares.items()}
+                    
+                    # Get profile load columns
+                    cols_profile = [
+                        c for c in per_profile_df.columns if c.split("|", 1)[1] == profile
+                    ]
+                    if not cols_profile:
+                        continue
+                    load_profile = per_profile_df[cols_profile]
+                    
+                    # Process each technology
+                    for technology, share in tech_shares.items():
+                        if share <= 0:
+                            continue
+                        
+                        # Technology-specific key: "profile|technology"
+                        tech_key = f"{profile}|{technology}"
+                        
+                        # Get technology-specific flexibility (default to 0 if not specified)
+                        tech_flex = flexibility_fraction.get(tech_key, 0.0)
+                        if tech_flex <= 0:
+                            # Technology not flexible, skip
+                            continue
+                        
+                        # Get technology-specific shift_hours (default to profile-level if available)
+                        tech_shift_hours = shift_hours.get(tech_key, shift_hours.get(profile, 4))
+                        
+                        # Check if this technology is "negative only" (can only discharge, not charge)
+                        # Format: "profile|technology": true/false in dsr_config.get("negative_only", {})
+                        negative_only_config = dsr_config.get("negative_only", {})
+                        tech_negative_only_key = tech_key
+                        is_negative_only = negative_only_config.get(tech_negative_only_key, False)
+                        
+                        # Check for minimum load constraint (fraction of baseline, e.g. 0.70 = 70% minimum)
+                        # Format: "profile|technology": fraction in dsr_config.get("min_load", {})
+                        tech_min_load = min_load_config.get(tech_negative_only_key, None)
+                        if tech_min_load is not None:
+                            # min_load: 0.70 means load can only be reduced to 70% of baseline
+                            # Maximum reduction = 1.0 - min_load = 1.0 - 0.70 = 0.30 (30%)
+                            # But flexibility_fraction might be smaller (e.g., 0.10 = 10%)
+                            # So the actual maximum reduction is min(flexibility_fraction, 1.0 - min_load)
+                            max_reduction = min(tech_flex, 1.0 - tech_min_load)
+                            logger.debug(f"Technology {tech_key}: min_load={tech_min_load}, flexibility={tech_flex}, max_reduction={max_reduction}")
+                        else:
+                            max_reduction = tech_flex  # No min_load constraint, use full flexibility
+                        
+                        # Split load by technology share
+                        tech_load = load_profile * share
+                        P_flex = tech_load * tech_flex
+                        e_nom_per_col = P_flex.max() * tech_shift_hours
+                        
+                        # Column names are "node|profile"; index e_nom by node
+                        e_nom_series = pd.Series(
+                            e_nom_per_col.values,
+                            index=[c.split("|", 1)[0] for c in cols_profile],
+                        )
+                        e_nom_series = e_nom_series[e_nom_series > 0]
+                        if e_nom_series.empty:
+                            continue
+                        
+                        store_names = [
+                            f"{node} industry dsr {profile} {technology}" for node in e_nom_series.index
+                        ]
+                        e_nom = e_nom_series.values
+                        
+                        # Calculate P_flex per store (max power per node)
+                        # P_flex is a DataFrame with columns "node|profile", need to extract per node
+                        P_flex_per_store = []
+                        for node in e_nom_series.index:
+                            col_name = f"{node}|{profile}"
+                            if col_name in P_flex.columns:
+                                P_flex_per_store.append(P_flex[col_name].max())
+                            else:
+                                # Fallback: use e_nom / shift_hours
+                                P_flex_per_store.append(e_nom_series[node] / tech_shift_hours)
+                        P_flex_per_store = np.array(P_flex_per_store)
+                        
+                        # Get restriction_time: try technology-specific first, then profile-level
+                        restriction_time_tech = dsr_config.get("restriction_time", {}).get(tech_key)
+                        if restriction_time_tech is None:
+                            restriction_time_tech = dsr_config.get("restriction_time", {}).get(profile)
+                        
+                        # Use DSR profile if available
+                        if dsr_profile_df is not None:
+                            # Try technology-specific profile column first, then profile-level
+                            if tech_key in dsr_profile_df.columns:
+                                profile_vals = (
+                                    dsr_profile_df[tech_key].values * tech_flex * restriction_value
+                                )
+                            elif profile in dsr_profile_df.columns:
+                                profile_vals = (
+                                    dsr_profile_df[profile].values * tech_flex * restriction_value
+                                )
+                            else:
+                                profile_vals = None
+                            
+                            if profile_vals is not None:
+                                if is_negative_only:
+                                    # Negative only: can only discharge (reduce load), not charge (increase load)
+                                    # At checkpoint hours (profile_vals = 0): e_max_pu = 0, e_min_pu = 0 (must be at 0)
+                                    # At other hours (profile_vals = 1.0): e_max_pu = 0 (can't charge), e_min_pu = -flexibility (can discharge)
+                                    # Note: With e_cyclic=True, the store must return to 0 at checkpoints.
+                                    # The store can only discharge, so it must plan discharge to naturally return to 0
+                                    # by the checkpoint (e.g., by not discharging near the checkpoint, or by having
+                                    # the energy balance constraint force it back to 0)
+                                    e_max_pu = pd.DataFrame(
+                                        index=n.snapshots,
+                                        columns=store_names,
+                                        data=0.0,  # Can't charge at any hour (negative only)
+                                    )
+                                    # For negative_only: e_min_pu controls maximum discharge (load reduction)
+                                    # If min_load is set (e.g., 0.70), max reduction = min(flexibility, 1.0 - min_load)
+                                    # e_min_pu = -max_reduction at non-checkpoint hours
+                                    e_min_pu_vals = -max_reduction * profile_vals.reshape(-1, 1) * np.ones((len(n.snapshots), len(store_names)))
+                                    e_min_pu = pd.DataFrame(
+                                        index=n.snapshots,
+                                        columns=store_names,
+                                        data=e_min_pu_vals,
+                                    )
+                                    # At checkpoint hours, profile_vals = 0, so e_min_pu = 0, forcing store to 0
+                                    # At other hours, e_min_pu = -max_reduction, allowing discharge up to max_reduction
+                                else:
+                                    # Bidirectional: can charge and discharge
+                                    e_max_pu = pd.DataFrame(
+                                        index=n.snapshots,
+                                        columns=store_names,
+                                        data=profile_vals.reshape(-1, 1) * np.ones((len(n.snapshots), len(store_names))),
+                                    )
+                                    e_min_pu = -e_max_pu
+                            else:
+                                if is_negative_only:
+                                    e_max_pu = 0.0  # Can't charge
+                                    e_min_pu = -max_reduction * restriction_value  # Can discharge up to max_reduction
+                                else:
+                                    e_max_pu = tech_flex * restriction_value
+                                    e_min_pu = -e_max_pu
+                        else:
+                            if is_negative_only:
+                                e_max_pu = 0.0  # Can't charge
+                                e_min_pu = -max_reduction * restriction_value  # Can discharge up to max_reduction
+                            else:
+                                e_max_pu = tech_flex * restriction_value
+                                e_min_pu = -e_max_pu
+                        
+                        # Create flexibility buses and unidirectional links for each store
+                        # This allows for ramp limits and efficiencies to prevent rapid cycling
+                        flexibility_buses = [f"{node} industry dsr flexibility {profile} {technology}" 
+                                            for node in e_nom_series.index]
+                        load_buses = e_nom_series.index.tolist()  # Will be moved to "low voltage" later
+                        
+                        # Add flexibility buses
+                        n.add(
+                            "Bus",
+                            flexibility_buses,
+                            carrier="industry dsr flexibility",
+                        )
+                        
+                        # Charge links: load bus -> flexibility bus (increasing load)
+                        # When this link flows, store charges, load increases
+                        # For negative_only DSR, disable charge links (set p_nom=0 or p_max_pu=0)
+                        charge_link_names = [f"{store_name} charge" for store_name in store_names]
+                        if is_negative_only:
+                            # Negative only: can't charge, so set p_nom to 0
+                            charge_p_nom = np.zeros_like(P_flex_per_store)
+                        else:
+                            charge_p_nom = P_flex_per_store
+                        
+                        n.add(
+                            "Link",
+                            charge_link_names,
+                            bus0=load_buses,
+                            bus1=flexibility_buses,
+                            carrier="industry dsr charge",
+                            p_nom=charge_p_nom,
+                            p_min_pu=0.0,  # Unidirectional: only positive flow (charging)
+                            p_max_pu=1.0,
+                            efficiency=1.0,  # Can be configured later for losses
+                        )
+                        
+                        # Discharge links: flexibility bus -> load bus (decreasing load)
+                        # When this link flows, store discharges, load decreases
+                        discharge_link_names = [f"{store_name} discharge" for store_name in store_names]
+                        n.add(
+                            "Link",
+                            discharge_link_names,
+                            bus0=flexibility_buses,
+                            bus1=load_buses,
+                            carrier="industry dsr discharge",
+                            p_nom=P_flex_per_store,
+                            p_min_pu=0.0,  # Unidirectional: only positive flow (discharging)
+                            p_max_pu=1.0,
+                            efficiency=1.0,  # Can be configured later for losses
+                        )
+                        
+                        # Add store on flexibility bus
+                        # Store energy balance: e[t] = e[t-1] + charge_link[t] - discharge_link[t]
+                        # This means charge_link increases store energy, discharge_link decreases it
+                        n.add(
+                            "Store",
+                            store_names,
+                            bus=flexibility_buses,
+                            carrier="industry dsr",
+                            standing_loss=0.0,
+                            e_cyclic=True,
+                            e_initial=0.0,
+                            e_nom=e_nom,
+                            e_max_pu=e_max_pu,
+                            e_min_pu=e_min_pu,
+                        )
+                        
+                        # Add constraint: charge_link - discharge_link = store_p
+                        # This couples the links to the store dispatch
+                        # We'll add this constraint in solve_network.py after the model is created
+            else:
+                # No technology_breakdown provided: no DSR stores created
+                logger.info("No technology_breakdown provided. Industry DSR requires technology_breakdown to be defined.")
+                logger.info("No industry DSR stores will be created. Profiles will use baseline (fixed) load only.")
+            logger.info("Industry DSR Stores added.")
 
     n.add(
         "Bus",
@@ -6433,6 +6877,7 @@ if __name__ == "__main__":
             spatial=spatial,
             cf_industry=cf_industry,
             investment_year=investment_year,
+            snakemake=snakemake,
         )
 
     if options["shipping"]:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -512,7 +512,7 @@ def prepare_network(
         n.set_snapshots(n.snapshots[:nhours])
         n.snapshot_weightings[:] = 8760.0 / nhours
 
-    if foresight == "myopic":
+    if foresight == "myopic" and planning_horizons:
         add_land_use_constraint(n, planning_horizons)
 
     if foresight == "perfect":
@@ -1162,6 +1162,320 @@ def add_co2_atmosphere_constraint(n, snapshots):
             n.model.add_constraints(lhs <= rhs, name=f"GlobalConstraint-{name}")
 
 
+def add_dri_h2_coupling_constraint(n: pypsa.Network, snapshots: pd.DatetimeIndex) -> None:
+    """
+    Add coupling constraint between DRI DSR flexibility and H2 storage capacity.
+    
+    H2-DRI-EAF flexibility requires H2 storage to enable load shifting. This constraint
+    limits DRI load shifting based on available H2 storage capacity.
+    
+    Constraint: |DRI_DSR_dispatch| ≤ H2_storage_capacity / H2_per_DRI_ratio
+    
+    Parameters
+    ----------
+    n : pypsa.Network
+        The PyPSA network instance
+    snapshots : pd.DatetimeIndex
+        Simulation timesteps
+    """
+    # Check if industry DSR is enabled
+    industry_config = n.config.get("industry", {})
+    dsr_config = industry_config.get("dsr", {})
+    if not dsr_config.get("enable", False):
+        return
+    
+    # Get H2/DRI ratio from config (MWh_H2 per ton steel, or MWh_H2 per MWh_DRI)
+    # H2_DRI: 1.7 is MWh_H2 per ton steel
+    # We need to convert to MWh_H2 per MWh_DRI electricity
+    # elec_DRI: 0.322 MWh_el per ton steel
+    # So: MWh_H2 per MWh_el = H2_DRI / elec_DRI = 1.7 / 0.322 ≈ 5.28
+    h2_dri_ratio = industry_config.get("H2_DRI", 1.7)
+    elec_dri_ratio = industry_config.get("elec_DRI", 0.322)
+    
+    if elec_dri_ratio == 0:
+        logger.warning(
+            "elec_DRI is 0, cannot calculate H2_per_DRI_electricity_ratio for coupling constraint. "
+            "Skipping H2-DRI coupling constraint. DRI flexibility may be overestimated."
+        )
+        return
+    
+    h2_per_dri_elec = h2_dri_ratio / elec_dri_ratio  # MWh_H2 per MWh_DRI_electricity
+    
+    # Find DRI DSR stores (those with "H2-DRI-EAF" in the name)
+    industry_dsr_stores = n.stores[n.stores.carrier == "industry dsr"]
+    dri_stores = industry_dsr_stores[industry_dsr_stores.index.str.contains("H2-DRI-EAF", case=False, na=False)]
+    
+    if dri_stores.empty:
+        return  # No DRI stores, nothing to constrain
+    
+    # Find H2 storage stores
+    h2_stores = n.stores[n.stores.carrier == "H2 Store"]
+    
+    if h2_stores.empty:
+        logger.warning("H2-DRI-EAF DSR stores found but no H2 storage available. DRI flexibility may be overestimated.")
+        return
+    
+    # Get the model variables (only if model exists)
+    if not hasattr(n, "model") or n.model is None:
+        return
+    
+    # Create mapping: DRI store bus -> H2 store
+    # DRI stores are on "low voltage" buses, need to find corresponding H2 bus
+    dri_store_to_h2_store = {}
+    
+    for dri_store_name in dri_stores.index:
+        dri_bus = n.stores.loc[dri_store_name, "bus"]
+        # Extract node name from bus (e.g., "BE0 0 low voltage" -> "BE0 0")
+        node_name = dri_bus.replace(" low voltage", "").replace(" H2", "")
+        
+        # Find H2 store at the same node
+        h2_bus = f"{node_name} H2"
+        h2_store_at_node = h2_stores[h2_stores.bus == h2_bus]
+        
+        if not h2_store_at_node.empty:
+            # Use the first H2 store at this node (there should typically be one)
+            h2_store_name = h2_store_at_node.index[0]
+            dri_store_to_h2_store[dri_store_name] = h2_store_name
+        else:
+            logger.debug(f"No H2 storage found for DRI store {dri_store_name} at bus {dri_bus}")
+    
+    if not dri_store_to_h2_store:
+        logger.warning("No H2 storage found for any DRI DSR stores. DRI flexibility may be overestimated.")
+        return
+    
+    # Add constraints for each DRI store
+    store_p = n.model["Store-p"]  # Store dispatch (power)
+    
+    constraints_added = 0
+    for dri_store_name, h2_store_name in dri_store_to_h2_store.items():
+        # Get H2 storage capacity (nominal energy capacity)
+        h2_store_e_nom = n.stores.loc[h2_store_name, "e_nom"]
+        h2_store_extendable = n.stores.loc[h2_store_name, "e_nom_extendable"]
+        
+        if h2_store_extendable:
+            # For extendable stores, use the model variable
+            # This allows the optimizer to build H2 storage to enable DRI flexibility
+            h2_store_e_nom_var = n.model["Store-e_nom"].loc[h2_store_name]
+            # Constraint: |DRI dispatch| * H2_per_DRI ≤ H2_storage_capacity
+            # This means: max_dri_shift = H2_storage_capacity / H2_per_DRI
+            max_dri_shift = h2_store_e_nom_var / h2_per_dri_elec
+        elif pd.isna(h2_store_e_nom) or h2_store_e_nom == 0:
+            logger.debug(f"H2 store {h2_store_name} has no capacity, skipping constraint for {dri_store_name}")
+            continue
+        else:
+            # For fixed capacity, use the nominal value
+            max_dri_shift = h2_store_e_nom / h2_per_dri_elec
+        
+        # Constraint: |DRI dispatch| ≤ max_dri_shift
+        # This limits both positive (charge) and negative (discharge) dispatch
+        dri_dispatch = store_p.loc[:, dri_store_name]
+        
+        # Add upper bound: DRI dispatch ≤ max_dri_shift
+        n.model.add_constraints(
+            dri_dispatch <= max_dri_shift,
+            name=f"DRI_H2_coupling_upper_{dri_store_name}"
+        )
+        
+        # Add lower bound: DRI dispatch ≥ -max_dri_shift
+        n.model.add_constraints(
+            dri_dispatch >= -max_dri_shift,
+            name=f"DRI_H2_coupling_lower_{dri_store_name}"
+        )
+        
+        constraints_added += 1
+    
+    if constraints_added > 0:
+        logger.info(f"Added H2 storage coupling constraints for {constraints_added} DRI DSR stores (H2/DRI ratio: {h2_per_dri_elec:.2f} MWh_H2/MWh_el)")
+
+
+def add_dsr_link_store_coupling_constraint(n: pypsa.Network, snapshots: pd.DatetimeIndex) -> None:
+    """
+    Add constraint coupling DSR Links to Store dispatch.
+    
+    With the flexibility bus architecture:
+    - Store on flexibility bus
+    - Charge link: load bus -> flexibility bus (positive flow = charging)
+    - Discharge link: flexibility bus -> load bus (positive flow = discharging)
+    
+    Constraint: store_p = charge_link - discharge_link
+    This ensures the store dispatch matches the link flows.
+    
+    Parameters
+    ----------
+    n : pypsa.Network
+        The PyPSA network instance
+    snapshots : pd.DatetimeIndex
+        Simulation timesteps
+    """
+    # Check if industry DSR is enabled
+    industry_config = n.config.get("industry", {})
+    dsr_config = industry_config.get("dsr", {})
+    if not dsr_config.get("enable", False):
+        return
+    
+    # Find DSR stores
+    industry_dsr_stores = n.stores.index[n.stores.carrier == "industry dsr"]
+    if industry_dsr_stores.empty:
+        return
+    
+    # Find corresponding charge and discharge links
+    charge_links = n.links.index[n.links.carrier == "industry dsr charge"]
+    discharge_links = n.links.index[n.links.carrier == "industry dsr discharge"]
+    
+    if charge_links.empty or discharge_links.empty:
+        logger.warning("DSR stores found but charge/discharge links not found. Store-link coupling constraint skipped.")
+        return
+    
+    # Get model variables
+    if not hasattr(n, "model") or n.model is None:
+        return
+    
+    store_p = n.model["Store-p"]
+    link_p = n.model["Link-p"]
+    
+    # Match stores to links by name
+    # Store name: "BE0 0 industry dsr Iron & steel industry Scrap-EAF"
+    # Charge link: "BE0 0 industry dsr Iron & steel industry Scrap-EAF charge"
+    # Discharge link: "BE0 0 industry dsr Iron & steel industry Scrap-EAF discharge"
+    
+    constraints_added = 0
+    for store_name in industry_dsr_stores:
+        charge_link_name = f"{store_name} charge"
+        discharge_link_name = f"{store_name} discharge"
+        
+        if charge_link_name not in charge_links or discharge_link_name not in discharge_links:
+            logger.debug(f"Links not found for store {store_name}, skipping coupling constraint")
+            continue
+        
+        # Constraint: store_p = charge_link - discharge_link
+        # This means:
+        # - When charging: charge_link > 0, discharge_link = 0, store_p > 0
+        # - When discharging: charge_link = 0, discharge_link > 0, store_p < 0
+        store_dispatch = store_p.loc[:, store_name]
+        charge_flow = link_p.loc[:, charge_link_name]
+        discharge_flow = link_p.loc[:, discharge_link_name]
+        
+        n.model.add_constraints(
+            store_dispatch == charge_flow - discharge_flow,
+            name=f"DSR_link_store_coupling_{store_name}"
+        )
+        constraints_added += 1
+    
+    if constraints_added > 0:
+        logger.info(f"Added store-link coupling constraints for {constraints_added} DSR stores")
+
+
+def add_dsr_ramp_constraints(n: pypsa.Network, snapshots: pd.DatetimeIndex, dsr_config: dict) -> None:
+    """
+    Add ramp rate constraints for DSR Links to prevent rapid cycling.
+    
+    Limits the change in link dispatch per hour to prevent unrealistic
+    rapid charge/discharge switching.
+    
+    Parameters
+    ----------
+    n : pypsa.Network
+        The PyPSA network instance
+    snapshots : pd.DatetimeIndex
+        Simulation timesteps
+    dsr_config : dict
+        Industry DSR configuration
+    """
+    # Get ramp rate parameters from config (default: 0.5 = 50% of p_nom per hour)
+    ramp_rate_config = dsr_config.get("ramp_rate", {})
+    default_ramp_rate = ramp_rate_config.get("default", 0.5)  # 50% per hour
+    
+    # Find DSR links
+    charge_links = n.links.index[n.links.carrier == "industry dsr charge"]
+    discharge_links = n.links.index[n.links.carrier == "industry dsr discharge"]
+    
+    if charge_links.empty and discharge_links.empty:
+        return
+    
+    # Get model variables
+    if not hasattr(n, "model") or n.model is None:
+        return
+    
+    link_p = n.model["Link-p"]
+    
+    constraints_added = 0
+    
+    # Add ramp constraints for charge links
+    for link_name in charge_links:
+        # Get technology-specific ramp rate if available
+        # Link name: "BE0 0 industry dsr Iron & steel industry Scrap-EAF charge"
+        # Extract technology key: "Iron & steel industry|Scrap-EAF"
+        store_name = link_name.replace(" charge", "")
+        parts = store_name.split(" industry dsr ")
+        if len(parts) == 2:
+            profile_tech = parts[1]
+            if " " in profile_tech:
+                profile, tech = profile_tech.rsplit(" ", 1)
+                tech_key = f"{profile}|{tech}"
+                ramp_rate = ramp_rate_config.get(tech_key, default_ramp_rate)
+            else:
+                ramp_rate = default_ramp_rate
+        else:
+            ramp_rate = default_ramp_rate
+        
+        # Get link capacity
+        p_nom = n.links.loc[link_name, "p_nom"]
+        max_ramp = p_nom * ramp_rate
+        
+        link_dispatch = link_p.loc[:, link_name]
+        
+        # Ramp up: link[t] - link[t-1] <= max_ramp
+        # Ramp down: link[t] - link[t-1] >= -max_ramp
+        for t in range(1, len(snapshots)):
+            n.model.add_constraints(
+                link_dispatch.loc[snapshots[t]] - link_dispatch.loc[snapshots[t-1]] <= max_ramp,
+                name=f"DSR_charge_ramp_up_{link_name}_{t}"
+            )
+            n.model.add_constraints(
+                link_dispatch.loc[snapshots[t]] - link_dispatch.loc[snapshots[t-1]] >= -max_ramp,
+                name=f"DSR_charge_ramp_down_{link_name}_{t}"
+            )
+        constraints_added += 2 * (len(snapshots) - 1)
+    
+    # Add ramp constraints for discharge links
+    for link_name in discharge_links:
+        # Get technology-specific ramp rate if available
+        store_name = link_name.replace(" discharge", "")
+        parts = store_name.split(" industry dsr ")
+        if len(parts) == 2:
+            profile_tech = parts[1]
+            if " " in profile_tech:
+                profile, tech = profile_tech.rsplit(" ", 1)
+                tech_key = f"{profile}|{tech}"
+                ramp_rate = ramp_rate_config.get(tech_key, default_ramp_rate)
+            else:
+                ramp_rate = default_ramp_rate
+        else:
+            ramp_rate = default_ramp_rate
+        
+        # Get link capacity
+        p_nom = n.links.loc[link_name, "p_nom"]
+        max_ramp = p_nom * ramp_rate
+        
+        link_dispatch = link_p.loc[:, link_name]
+        
+        # Ramp up: link[t] - link[t-1] <= max_ramp
+        # Ramp down: link[t] - link[t-1] >= -max_ramp
+        for t in range(1, len(snapshots)):
+            n.model.add_constraints(
+                link_dispatch.loc[snapshots[t]] - link_dispatch.loc[snapshots[t-1]] <= max_ramp,
+                name=f"DSR_discharge_ramp_up_{link_name}_{t}"
+            )
+            n.model.add_constraints(
+                link_dispatch.loc[snapshots[t]] - link_dispatch.loc[snapshots[t-1]] >= -max_ramp,
+                name=f"DSR_discharge_ramp_down_{link_name}_{t}"
+            )
+        constraints_added += 2 * (len(snapshots) - 1)
+    
+    if constraints_added > 0:
+        logger.info(f"Added ramp rate constraints for {len(charge_links) + len(discharge_links)} DSR links ({constraints_added} total constraints)")
+
+
 def extra_functionality(
     n: pypsa.Network, snapshots: pd.DatetimeIndex, planning_horizons: str | None = None
 ) -> None:
@@ -1207,6 +1521,14 @@ def extra_functionality(
     ):
         add_solar_potential_constraints(n, config)
 
+    # Add DRI-H2 coupling constraint if industry DSR is enabled
+    industry_config = n.config.get("industry", {})
+    dsr_config = industry_config.get("dsr", {})
+    if dsr_config.get("enable", False):
+        add_dri_h2_coupling_constraint(n, snapshots)
+        add_dsr_link_store_coupling_constraint(n, snapshots)
+        add_dsr_ramp_constraints(n, snapshots, dsr_config)
+    
     if n.config.get("sector", {}).get("tes", False):
         if n.buses.index.str.contains(
             r"urban central heat|urban decentral heat|rural heat",
@@ -1270,129 +1592,142 @@ def check_objective_value(n: pypsa.Network, solving: dict) -> None:
             )
 
 
-def solve_network(
-    n: pypsa.Network,
+def collect_kwargs(
     config: dict,
-    params: dict,
     solving: dict,
-    rule_name: str | None = None,
     planning_horizons: str | None = None,
-    **kwargs,
-) -> None:
+    log_fn: str | None = None,
+    mode: str = "single",
+) -> tuple[dict, dict]:
     """
-    Solve network optimization problem.
+    Prepare keyword arguments separated for model creation and model solving.
 
     Parameters
     ----------
-    n : pypsa.Network
-        The PyPSA network instance
-    config : Dict
+    config : dict
         Configuration dictionary containing solver settings
-    params : Dict
-        Dictionary of solving parameters
-    solving : Dict
+    solving : dict
         Dictionary of solving options and configuration
-    rule_name : str, optional
-        Name of the snakemake rule being executed
     planning_horizons : str, optional
-            The current planning horizon year or None in perfect foresight
-    **kwargs
-        Additional keyword arguments passed to the solver
+        The current planning horizon year or None in perfect foresight
+    log_fn : str, optional
+        Path to solver log file
+    mode : str, optional
+        Optimization mode: 'single', 'rolling_horizon', or 'iterative'
+        Default is 'single'
 
     Returns
     -------
-    n : pypsa.Network
-        Solved network instance
-    status : str
-        Solution status
-    condition : str
-        Termination condition
-
-    Raises
-    ------
-    RuntimeError
-        If solving status is infeasible or warning
-    ObjectiveValueError
-        If objective value differs from expected value
+    tuple[dict, dict]
+        Two dictionaries: (model_kwargs, solve_kwargs)
+        - model_kwargs: Arguments for n.optimize.create_model()
+        - solve_kwargs: Arguments for n.optimize.solve_model()
+        For 'rolling_horizon' and 'iterative' modes, returns merged kwargs
+        with additional mode-specific parameters
     """
     set_of_options = solving["solver"]["options"]
     cf_solving = solving["options"]
 
-    kwargs["multi_investment_periods"] = config["foresight"] == "perfect"
-    kwargs["solver_options"] = (
-        solving["solver_options"][set_of_options] if set_of_options else {}
-    )
-    kwargs["solver_name"] = solving["solver"]["name"]
-    kwargs["extra_functionality"] = partial(
-        extra_functionality, planning_horizons=planning_horizons
-    )
-    kwargs["transmission_losses"] = cf_solving.get("transmission_losses", False)
-    kwargs["linearized_unit_commitment"] = cf_solving.get(
+    # Model creation kwargs
+    model_kwargs = {}
+    model_kwargs["multi_investment_periods"] = config["foresight"] == "perfect"
+    model_kwargs["transmission_losses"] = cf_solving.get("transmission_losses", False)
+    model_kwargs["linearized_unit_commitment"] = cf_solving.get(
         "linearized_unit_commitment", False
     )
-    kwargs["assign_all_duals"] = cf_solving.get("assign_all_duals", False)
-    kwargs["io_api"] = cf_solving.get("io_api", None)
+
+    # Solve kwargs
+    solver_name = solving["solver"]["name"]
+    solver_options = solving["solver_options"][set_of_options] if set_of_options else {}
+
+    solve_kwargs = {}
+    solve_kwargs["solver_name"] = solver_name
+    solve_kwargs["solver_options"] = solver_options
+    solve_kwargs["assign_all_duals"] = cf_solving.get("assign_all_duals", False)
+    solve_kwargs["io_api"] = cf_solving.get("io_api", None)
+    solve_kwargs["keep_files"] = cf_solving.get("keep_files", False)
+
+    if log_fn:
+        solve_kwargs["log_fn"] = log_fn
 
     oetc = solving.get("oetc", None)
     if oetc:
         oetc["credentials"] = OetcCredentials(
             email=os.environ["OETC_EMAIL"], password=os.environ["OETC_PASSWORD"]
         )
-        oetc["solver"] = kwargs["solver_name"]
-        oetc["solver_options"] = kwargs["solver_options"]
+        oetc["solver"] = solver_name
+        oetc["solver_options"] = solver_options
         oetc_settings = OetcSettings(**oetc)
         oetc_handler = OetcHandler(oetc_settings)
-        kwargs["remote"] = oetc_handler
+        solve_kwargs["remote"] = oetc_handler
 
-    kwargs["model_kwargs"] = cf_solving.get("model_kwargs", {})
-    kwargs["keep_files"] = cf_solving.get("keep_files", False)
-
-    if kwargs["solver_name"] == "gurobi":
+    if solver_name == "gurobi":
         logging.getLogger("gurobipy").setLevel(logging.CRITICAL)
 
-    rolling_horizon = cf_solving.pop("rolling_horizon", False)
-    skip_iterations = cf_solving.pop("skip_iterations", False)
-    if not n.lines.s_nom_extendable.any():
-        skip_iterations = True
-        logger.info("No expandable lines found. Skipping iterative solving.")
+    # Handle special modes
+    if mode == "rolling_horizon":
+        all_kwargs = {**model_kwargs, **solve_kwargs}
+        all_kwargs["horizon"] = cf_solving.get("horizon", 365)
+        all_kwargs["overlap"] = cf_solving.get("overlap", 0)
+        return all_kwargs, {}
 
-    # add to network for extra_functionality
+    elif mode == "iterative":
+        all_kwargs = {**model_kwargs, **solve_kwargs}
+        all_kwargs["track_iterations"] = cf_solving["track_iterations"]
+        all_kwargs["min_iterations"] = cf_solving["min_iterations"]
+        all_kwargs["max_iterations"] = cf_solving["max_iterations"]
+
+        if cf_solving["post_discretization"].get("enable", False):
+            logger.info("Add post-discretization parameters.")
+            all_kwargs.update(cf_solving["post_discretization"])
+
+        return all_kwargs, {}
+
+    return model_kwargs, solve_kwargs
+
+
+def create_optimization_model(
+    n: pypsa.Network,
+    config: dict,
+    params: dict,
+    model_kwargs: dict,
+    solve_kwargs: dict,
+    planning_horizons: str | None = None,
+) -> None:
+    """
+    Prepare optimization problem by creating model and adding extra functionality.
+
+    This function:
+    1. Attaches config and params to network for extra_functionality
+    2. Creates the optimization model
+    3. Adds extra functionality (custom constraints)
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        The PyPSA network instance
+    config : dict
+        Configuration dictionary containing solver settings
+    params : dict
+        Dictionary of solving parameters
+    model_kwargs : dict
+        Arguments for n.optimize.create_model()
+    solve_kwargs : dict
+        Arguments for n.optimize.solve_model()
+    planning_horizons : str, optional
+        The current planning horizon year or None in perfect foresight
+    """
+    # Add config and params to network for extra_functionality
     n.config = config
     n.params = params
 
-    if rolling_horizon and rule_name == "solve_operations_network":
-        kwargs["horizon"] = cf_solving.get("horizon", 365)
-        kwargs["overlap"] = cf_solving.get("overlap", 0)
-        n.optimize.optimize_with_rolling_horizon(**kwargs)
-        status, condition = "", ""
-    elif skip_iterations:
-        status, condition = n.optimize(**kwargs)
-    else:
-        kwargs["track_iterations"] = cf_solving["track_iterations"]
-        kwargs["min_iterations"] = cf_solving["min_iterations"]
-        kwargs["max_iterations"] = cf_solving["max_iterations"]
-        if cf_solving["post_discretization"].pop("enable"):
-            logger.info("Add post-discretization parameters.")
-            kwargs.update(cf_solving["post_discretization"])
-        status, condition = n.optimize.optimize_transmission_expansion_iteratively(
-            **kwargs
-        )
+    # Create optimization model
+    logger.info("Creating optimization model...")
+    n.optimize.create_model(**model_kwargs)
 
-    if not rolling_horizon:
-        if status != "ok":
-            logger.warning(
-                f"Solving status '{status}' with termination condition '{condition}'"
-            )
-        check_objective_value(n, solving)
-
-    if "warning" in condition:
-        raise RuntimeError("Solving status 'warning'. Discarding solution.")
-
-    if "infeasible" in condition:
-        labels = n.model.compute_infeasibilities()
-        logger.info(f"Labels:\n{labels}")
-        n.model.print_infeasibilities()
-        raise RuntimeError("Solving status 'infeasible'. Infeasibilities computed.")
+    # Add extra functionality (custom constraints)
+    logger.info("Adding extra functionality (custom constraints)...")
+    extra_functionality(n, n.snapshots, planning_horizons)
 
 
 if __name__ == "__main__":
@@ -1412,12 +1747,15 @@ if __name__ == "__main__":
     update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
     solve_opts = snakemake.params.solving["options"]
+    cf_solving = snakemake.params.solving["options"]
 
     np.random.seed(solve_opts.get("seed", 123))
 
+    # Load network
     n = pypsa.Network(snakemake.input.network)
     planning_horizons = snakemake.wildcards.get("planning_horizons", None)
 
+    # Prepare network (settings before solving)
     prepare_network(
         n,
         solve_opts=snakemake.params.solving["options"],
@@ -1427,23 +1765,99 @@ if __name__ == "__main__":
         limit_max_growth=snakemake.params.get("sector", {}).get("limit_max_growth"),
     )
 
+    # Determine solve mode
+    rolling_horizon = cf_solving.get("rolling_horizon", False)
+    skip_iterations = cf_solving.get("skip_iterations", False)
+
+    if not n.lines.s_nom_extendable.any():
+        skip_iterations = True
+        logger.info("No expandable lines found. Skipping iterative solving.")
+
     logging_frequency = snakemake.config.get("solving", {}).get(
         "mem_logging_frequency", 30
     )
+
+    # Solve network based on mode
     with memory_logger(
         filename=getattr(snakemake.log, "memory", None), interval=logging_frequency
     ) as mem:
-        solve_network(
-            n,
-            config=snakemake.config,
-            params=snakemake.params,
-            solving=snakemake.params.solving,
-            planning_horizons=planning_horizons,
-            rule_name=snakemake.rule,
-            log_fn=snakemake.log.solver,
-        )
+        if rolling_horizon and snakemake.rule == "solve_operations_network":
+            logger.info("Using rolling horizon optimization...")
+            all_kwargs, _ = collect_kwargs(
+                snakemake.config,
+                snakemake.params.solving,
+                planning_horizons,
+                log_fn=snakemake.log.solver,
+                mode="rolling_horizon",
+            )
+
+            n.config = snakemake.config
+            n.params = snakemake.params
+            all_kwargs["extra_functionality"] = partial(
+                extra_functionality, planning_horizons=planning_horizons
+            )
+            n.optimize.optimize_with_rolling_horizon(**all_kwargs)
+            status, condition = "", ""
+
+        elif skip_iterations:
+            logger.info("Using single-pass optimization...")
+            model_kwargs, solve_kwargs = collect_kwargs(
+                snakemake.config,
+                snakemake.params.solving,
+                planning_horizons,
+                log_fn=snakemake.log.solver,
+                mode="single",
+            )
+            create_optimization_model(
+                n,
+                config=snakemake.config,
+                params=snakemake.params,
+                model_kwargs=model_kwargs,
+                solve_kwargs=solve_kwargs,
+                planning_horizons=planning_horizons,
+            )
+
+            logger.info("Solving model...")
+            status, condition = n.optimize.solve_model(**solve_kwargs)
+
+        else:
+            logger.info("Using iterative transmission expansion optimization...")
+
+            all_kwargs, _ = collect_kwargs(
+                snakemake.config,
+                snakemake.params.solving,
+                planning_horizons,
+                log_fn=snakemake.log.solver,
+                mode="iterative",
+            )
+
+            n.config = snakemake.config
+            n.params = snakemake.params
+            all_kwargs["extra_functionality"] = partial(
+                extra_functionality, planning_horizons=planning_horizons
+            )
+            status, condition = n.optimize.optimize_transmission_expansion_iteratively(
+                **all_kwargs
+            )
 
     logger.info(f"Maximum memory usage: {mem.mem_usage}")
+
+    # Check results
+    if not rolling_horizon:
+        if status != "ok":
+            logger.warning(
+                f"Solving status '{status}' with termination condition '{condition}'"
+            )
+        check_objective_value(n, snakemake.params.solving)
+
+    if "warning" in condition:
+        raise RuntimeError("Solving status 'warning'. Discarding solution.")
+
+    if "infeasible" in condition:
+        labels = n.model.compute_infeasibilities()
+        logger.info(f"Labels:\n{labels}")
+        n.model.print_infeasibilities()
+        raise RuntimeError("Solving status 'infeasible'. Infeasibilities computed.")
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
     n.export_to_netcdf(snakemake.output.network)


### PR DESCRIPTION


## Changes proposed in this Pull Request
### Summary

This branch implements **industry electricity demand‑side response (DSR)** based on **temporal FfE profiles**, modeling industrial flexibility as **virtual storage** that can shift part of the load in time while preserving total energy demand.

### Key changes

- **FfE‑based temporal industrial load**
  - Extend `build_industrial_energy_demand_per_node.py` and Snakemake rules so that, in addition to annual energy:
    - Hourly **per‑node** industrial electricity demand is built.
    - Hourly **per‑node, per‑FfE‑profile** demand is built (`industrial_electricity_demand_per_profile_temporal`).
  - This uses FfE load profiles to give each industrial sector its own time series.

- **Industry DSR checkpoint profiles**
  - New script `build_industry_dsr_profile.py` + rule `build_industry_dsr_profile`:
    - Builds hourly **checkpoint profiles** (0 at selected `restriction_time` hours, 1 elsewhere) per FfE profile/technology.
    - These are applied as time‑varying `e_max_pu`/`e_min_pu` so that DSR stores must be **empty at checkpoint hours**, enforcing demand balance over each period (e.g. per day), not just over the full year.

- **Technology‑specific DSR**
  - In `prepare_sector_network.py` (`add_industry`):
    - Introduce `industry.dsr.technology_breakdown` to split each FfE profile into technologies (e.g. `"Iron & steel industry"` → Scrap‑EAF, H2‑DRI‑EAF, BF‑BOF‑CCUS, Aluminium‑primary, …).
    - Optional **auto‑calculation** of technology shares from industrial production data (steel & aluminium), with manual shares overriding.
    - Only profiles with a breakdown get DSR stores; others remain as fixed load.

- **DSR store + flexibility bus architecture**
  - For each `(node, FfE profile, technology)`:
    - Compute flexible power from temporal load × `flexibility_fraction["profile|technology"]`.
    - Size the **energy buffer** `e_nom = P_flex,max × shift_hours["profile|technology"]`.
    - Create:
      - A **flexibility bus** per `(node, profile, technology)`.
      - A **charge link** (load bus → flexibility bus) and **discharge link** (flexibility bus → load bus), unidirectional and with configurable ramp limits.
      - A **Store** on the flexibility bus with:
        - `carrier="industry dsr"`, `e_cyclic=True`, `e_initial=0`.
        - Time‑varying `e_max_pu`/`e_min_pu` from the checkpoint profile × flexibility fraction × restriction value.
      - Support **negative‑only DSR** and **min‑load**:
        - For technologies that can only reduce load: `e_max_pu = 0`, `e_min_pu = -max_reduction`, with `max_reduction` capped by `min_load` if set.

- **Custom constraints in `solve_network.py`**
  - **Store–link coupling** (`add_dsr_link_store_coupling_constraint`):  
    \[
    p_\text{store}(t) = p_\text{charge\_link}(t) - p_\text{discharge\_link}(t)
    \]
    Ensures DSR store state and link flows are consistent.
  - **DSR ramp‑rate limits** (`add_dsr_ramp_constraints`):
    - Per‑technology ramp rate (default 50% of `p_nom` per hour) for charge/discharge links, to suppress unrealistic hour‑to‑hour “sawtooth” switching.
  - **H₂–DRI–EAF coupling** (`add_dri_h2_coupling_constraint`):
    - Limits DRI DSR dispatch by available H₂ storage capacity, using `H2_DRI` and `elec_DRI` config parameters.
    - Works for both fixed and extendable H₂ storage.

- **Config and rules wiring**
  - `industry.dsr.*` section extended with:
    - Per‑FfE and per‑technology **flexibility fractions**, **shift hours**, **restriction times**, and optional **negative_only/min_load**.
  - `rules/build_sector.smk` wired so that, when `industry.temporal_electricity_industry_load: true` and `industry.dsr.enable: true`:
    - Temporal FfE electricity profiles and DSR checkpoint profiles are built and passed into `prepare_sector_network`.
  - `rules/postprocess.smk` adds optional plotting rules:
    - `plot_industry_dsr_comparison`, `plot_industry_dsr_price_correlation`, `plot_industry_load_price_correlation` to visualize flexibility behavior vs baseline and prices.

### Problems encountered and design decisions

- **Simultaneous charge and discharge on DSR links**
  - Diagnostics showed cases where **charge and discharge links were both positive and equal** (e.g. 24.7 MW each), yielding net store dispatch of zero.
  - This is mathematically allowed by `store_p = charge − discharge` but physically odd (circulating power with no net effect).
  - It was judged an **inefficiency rather than a hard violation**, especially once ramp constraints are active.

- **Attempted mutual exclusivity (now removed)**
  - We briefly introduced a **binary‑variable mutual exclusivity** constraint to forbid simultaneous charge & discharge:
    - Added MILP with ~4,200 binaries (per DSR store and snapshot), using a big‑M formulation.
  - In practice:
    - HiGHS presolve eliminated binaries and the solver got effectively stuck (no progress after hours).
    - This significantly increased complexity and threatened numerical stability.
  - **Decision**:
    - Remove mutual exclusivity from `solve_network.py` and keep the model **LP‑only**, relying instead on:
      - Store–link coupling for consistency.
      - Ramp constraints to prevent pathological rapid cycling.
    - Simultaneous flows are accepted as long as net behavior is reasonable.


### Current behavior (intended)

- Industrial electricity demand is:
  - **Temporal** (hourly) and **per FfE sector** using FfE profiles.
- DSR is:
  - **Per node, per profile, per technology**, with configurable flexible shares and shift windows.
  - **Energy‑neutral** over the horizon and approximately balanced **per period** between checkpoint hours.
- Constraints ensure:
  - **Consistent store–link physics** (store_p = charge − discharge).
  - **Limited ramping**, avoiding high‑frequency on/off behavior.
  - **Optional negative‑only and min‑load** constraints for specific technologies.
  - **H₂‑DRI coupling** limiting DRI flexibility by H₂ storage.


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] For new data sources or versions, `these instructions <https://pypsa-eur.readthedocs.io/en/latest/data_sources.html>`_ have been followed.
- [ ] A release note `doc/release_notes.rst` is added.
