### PR TITLE
ci: exclude packages newer than 7 days in lockfile update workflow

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -20,10 +20,15 @@ jobs:
       with:
         pixi-version: v0.59.0
 
-    - name: Full resolve
+    - name: Full resolve (exclude packages newer than 7 days)
+      # Exclude recently published packages to avoid pulling in broken or
+      # yanked releases before upstream has had time to react
       run: |
+        EXCLUDE_DATE=$(date -u -d '7 days ago' +%Y-%m-%dT00:00:00Z)
+        sed -i "/^\[workspace\]/a exclude-newer = \"$EXCLUDE_DATE\"" pixi.toml
         rm pixi.lock
         pixi install --all
+        git checkout pixi.toml
 
     - name: Export conda environment files
       if: ${{ !vars.PYPSA_BOT_ID }}

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,7 +8,9 @@ Release Notes
 
 .. Upcoming Release
 .. =================
-* The industry reference year and the ammonia production data have been updated to 2023 (https://github.com/PyPSA/pypsa-eur/pull/2103) 
+* The lockfile update workflow now excludes packages published within the last 7 days to reduce the risk of pulling in broken or yanked releases (https://github.com/PyPSA/pypsa-eur/pull/2130).
+
+* The industry reference year and the ammonia production data have been updated to 2023 (https://github.com/PyPSA/pypsa-eur/pull/2103)
 
 * refactor: Use scripts path provider consistently (https://github.com/PyPSA/pypsa-eur/pull/2093).
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR cherry-pick upstream PR https://github.com/PyPSA/pypsa-eur/pull/2130. This brings in security changes to the lockfile update workflow to reduce the risk of pulling in broken or yanked releases.

## Checklist

**Required:**
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.