### PR TITLE
Build and add heavy transport, buses, vans availability

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -26,6 +26,11 @@ from scripts.lib.validation.config import validate_config
 configfile: "config/config.default.yaml"
 configfile: "config/plotting.default.yaml"
 
+# PyPSA-Eurelectric fork defaults (e.g. mobility_profiles source: build). Loads before
+# optional config/config.yaml so a local config.yaml can still override everything.
+if Path("config/config.eurelectric.default.yaml").exists():
+    configfile: "config/config.eurelectric.default.yaml"
+
 
 # Config stacking: override defaults with small scenario files via CLI:
 #   snakemake -call --configfile config/config.eurelectric.default.yaml config/test/config.eu_38_2030_base.yaml config/test/config.dsr_v3_test.yaml

--- a/config/config.eurelectric.default.yaml
+++ b/config/config.eurelectric.default.yaml
@@ -71,6 +71,16 @@ clustering:
     resolution_sector: 3h
 
 # =============================================================================
+# DATASETS (override defaults from config.default.yaml)
+# =============================================================================
+# Build BASt mobility profiles locally so extended CSVs (bus, hd, lfw) are
+# produced. Archive mode only retrieves pre-built kfz/pkw from pypsa.org.
+data:
+  mobility_profiles:
+    source: build
+    version: latest
+
+# =============================================================================
 # SECTOR COUPLING SETTINGS
 # =============================================================================
 sector:
@@ -99,6 +109,16 @@ sector:
   # Electric vehicle flexibility
   bev_dsm: true
   v2g: true
+
+  # Class-specific plugged-in availability assumptions
+  pkw_bev_avail_max: 0.95
+  pkw_bev_avail_mean: 0.80
+  bus_bev_avail_max: 0.90
+  bus_bev_avail_mean: 0.60
+  hd_bev_avail_max: 0.85
+  hd_bev_avail_mean: 0.70
+  lfw_bev_avail_max: 0.92
+  lfw_bev_avail_mean: 0.70
 
 # =============================================================================
 # INDUSTRY SETTINGS

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1400,9 +1400,12 @@ if MOBILITY_PROFILES_DATASET["source"] in ["build"]:
                 ),
             ),
         output:
-            raw_files=directory(MOBILITY_PROFILES_DATASET["folder"] / "raw"),
-            kfz=MOBILITY_PROFILES_DATASET["folder"] / "kfz.csv",
-            pkw=MOBILITY_PROFILES_DATASET["folder"] / "pkw.csv",
+            raw_files=directory(f"{MOBILITY_PROFILES_DATASET['folder']}/raw"),
+            kfz=f"{MOBILITY_PROFILES_DATASET['folder']}/kfz.csv",
+            pkw=f"{MOBILITY_PROFILES_DATASET['folder']}/pkw.csv",
+            bus=f"{MOBILITY_PROFILES_DATASET['folder']}/bus.csv",
+            hd=f"{MOBILITY_PROFILES_DATASET['folder']}/hd.csv",
+            lfw=f"{MOBILITY_PROFILES_DATASET['folder']}/lfw.csv",
         threads: 1
         resources:
             mem_mb=5000,
@@ -1431,11 +1434,17 @@ rule build_transport_demand:
         transport_data=resources("transport_data.csv"),
         traffic_data_KFZ=f"{MOBILITY_PROFILES_DATASET['folder']}/kfz.csv",
         traffic_data_Pkw=f"{MOBILITY_PROFILES_DATASET['folder']}/pkw.csv",
+        traffic_data_Bus=f"{MOBILITY_PROFILES_DATASET['folder']}/bus.csv",
+        traffic_data_HD=f"{MOBILITY_PROFILES_DATASET['folder']}/hd.csv",
+        traffic_data_LFW=f"{MOBILITY_PROFILES_DATASET['folder']}/lfw.csv",
         temp_air_total=resources("temp_air_total_base_s_{clusters}.nc"),
     output:
         transport_demand=resources("transport_demand_s_{clusters}.csv"),
         transport_data=resources("transport_data_s_{clusters}.csv"),
-        avail_profile=resources("avail_profile_s_{clusters}.csv"),
+        avail_profile_pkw=resources("avail_profile_pkw_s_{clusters}.csv"),
+        avail_profile_bus=resources("avail_profile_bus_s_{clusters}.csv"),
+        avail_profile_hd=resources("avail_profile_hd_s_{clusters}.csv"),
+        avail_profile_lfw=resources("avail_profile_lfw_s_{clusters}.csv"),
         dsm_profile=resources("dsm_profile_s_{clusters}.csv"),
     threads: 1
     resources:

--- a/scripts/build_mobility_profiles.py
+++ b/scripts/build_mobility_profiles.py
@@ -103,6 +103,18 @@ if __name__ == "__main__":
                 "KFZ_R2",
                 "Pkw_R1",
                 "Pkw_R2",
+            # Adding Buses, Van and Heavy Duty vehicles 
+            # 'loA, Lzg, Sat' is trucks, 'lfw' is van, 'bus' is buses,     
+                "Bus_R1",
+                "Bus_R2",
+                "LoA_R1",
+                "LoA_R2",
+                "Lzg_R1",
+                "Lzg_R2",
+                "Sat_R1",
+                "Sat_R2",
+                "Lfw_R1",
+                "Lfw_R2",
             ],
         )
 
@@ -122,12 +134,33 @@ if __name__ == "__main__":
 
     # Aggregate data for both directions on the road
     vehicle_counts["kfz"] = vehicle_counts["KFZ_R1"] + vehicle_counts["KFZ_R2"]
-    vehicle_counts["pkw"] = vehicle_counts["Pkw_R1"] + vehicle_counts["Pkw_R2"]
+
+    # Raw passenger-like class from BASt
+    vehicle_counts["pkw_raw"] = vehicle_counts["Pkw_R1"] + vehicle_counts["Pkw_R2"]
+
+    # Vans (Light commercial vehicles)
+    vehicle_counts["lfw"] = vehicle_counts['Lfw_R1'] + vehicle_counts['Lfw_R2']
+
+    # Convention 1: passenger cars excluding vans
+    vehicle_counts["pkw"] = (vehicle_counts["pkw_raw"] - vehicle_counts["lfw"]).clip(lower=0)
+
+    # Buses
+    vehicle_counts["bus"] = vehicle_counts["Bus_R1"] + vehicle_counts["Bus_R2"]
+
+    # Heavy duty: LoA + Lzg + Sat
+    vehicle_counts["hd"] = (
+        vehicle_counts["LoA_R1"] + vehicle_counts["LoA_R2"]
+        + vehicle_counts["Lzg_R1"] + vehicle_counts["Lzg_R2"]
+        + vehicle_counts["Sat_R1"] + vehicle_counts["Sat_R2"]
+    )
 
     # vehicles types to aggregate for and output files to write to
     vehicle_types = {
         "kfz": snakemake.output["kfz"],
         "pkw": snakemake.output["pkw"],
+        "bus": snakemake.output["bus"],
+        "hd": snakemake.output["hd"],
+        "lfw": snakemake.output["lfw"],
     }
     for vehicle_type, output_file in vehicle_types.items():
         logger.info(f"Aggregating and writing {vehicle_type} data to {output_file}")

--- a/scripts/build_transport_demand.py
+++ b/scripts/build_transport_demand.py
@@ -126,33 +126,23 @@ def transport_degree_factor(
     return dd
 
 
-def bev_availability_profile(fn, snapshots, nodes, options):
-    """
-    Derive plugged-in availability for passenger electric vehicles.
-    """
-    # car count in typical week
+def vehicle_availability_profile(fn, snapshots, nodes, avail_max, avail_mean, label):
     traffic = pd.read_csv(fn, skiprows=2, usecols=["count"]).squeeze("columns")
-    # maximum share plugged-in availability for passenger electric vehicles
-    avail_max = options["bev_avail_max"]
-    # average share plugged-in availability for passenger electric vehicles
-    avail_mean = options["bev_avail_mean"]
 
-    # linear scaling, highest when traffic is lowest, decreases if traffic increases
-    avail = avail_max - (avail_max - avail_mean) * (traffic - traffic.min()) / (
-        traffic.mean() - traffic.min()
+    avail = avail_max - (avail_max - avail_mean) * (traffic - traffic.min()) / (traffic.mean() - traffic.min()
     )
 
     if not avail[avail < 0].empty:
         logger.warning(
-            "The BEV availability weekly profile has negative values which can "
-            "lead to infeasibility."
+            f"The {label} weekly availability profile has negative values, which can cause infeasibility."
         )
-
     return generate_periodic_profiles(
         dt_index=snapshots,
         nodes=nodes,
         weekly_profile=avail.values,
-    )
+    )        
+
+
 
 
 def bev_dsm_profile(snapshots, nodes, options):
@@ -202,18 +192,53 @@ if __name__ == "__main__":
     )
 
     transport_demand = build_transport_demand(
-        snakemake.input.traffic_data_KFZ,
+        snakemake.input.traffic_data_Pkw,
         nodes,
         nodal_transport_data,
     )
 
-    avail_profile = bev_availability_profile(
-        snakemake.input.traffic_data_Pkw, snapshots, nodes, options
+    avail_profile_pkw = vehicle_availability_profile(
+        snakemake.input.traffic_data_Pkw,
+        snapshots,
+        nodes,
+        options["pkw_bev_avail_max"],
+        options["pkw_bev_avail_mean"],
+        label="PKW",
+    )
+    
+    avail_profile_bus = vehicle_availability_profile(
+        snakemake.input.traffic_data_Bus,
+        snapshots,
+        nodes,
+        options["bus_bev_avail_max"],
+        options["bus_bev_avail_mean"],
+        label="BUS",
+    )
+
+    avail_profile_hd = vehicle_availability_profile(
+        snakemake.input.traffic_data_HD,
+        snapshots,
+        nodes,
+        options["hd_bev_avail_max"],
+        options["hd_bev_avail_mean"],
+        label="HD",
+    )
+
+    avail_profile_lfw = vehicle_availability_profile(
+        snakemake.input.traffic_data_LFW,
+        snapshots,
+        nodes,
+        options["lfw_bev_avail_max"],
+        options["lfw_bev_avail_mean"],
+        label="LFW",
     )
 
     dsm_profile = bev_dsm_profile(snapshots, nodes, options)
 
     nodal_transport_data.to_csv(snakemake.output.transport_data)
     transport_demand.to_csv(snakemake.output.transport_demand)
-    avail_profile.to_csv(snakemake.output.avail_profile)
+    avail_profile_pkw.to_csv(snakemake.output.avail_profile_pkw)
+    avail_profile_bus.to_csv(snakemake.output.avail_profile_bus)
+    avail_profile_hd.to_csv(snakemake.output.avail_profile_hd)
+    avail_profile_lfw.to_csv(snakemake.output.avail_profile_lfw)
     dsm_profile.to_csv(snakemake.output.dsm_profile)


### PR DESCRIPTION
# Extend BASt mobility profiles and sector availability for bus, heavy-duty, and vans (PKW excl. Lfw)

## Summary

This PR extends the BASt-based mobility pipeline beyond aggregate `KFZ` and `PKW` counts.

It adds weekly `bus`, `hd`, and `lfw` traffic profiles, applies an explicit `PKW` definition excluding vans, wires `build_transport_demand` to read those traffic CSVs, and emits class-specific EV charging availability time series for:

- `PKW`
- `bus`
- `HD`
- `LFW`

Land-transport energy demand (`transport_demand`) remains driven by `PKW` traffic and passenger-car statistics in `transport_data.csv`.

Network integration of separate loads/chargers per vehicle class is left for a follow-up implementation phase.

## Motivation

Road transport electrification and flexibility, including availability and potential V2G, should eventually be distinguishable by vehicle class.

BASt monitoring files already expose `Bus`, `Lfw`, and heavy-duty-related columns (`LoA`, `Lzg`, `Sat`). This PR aggregates them consistently with the existing `kfz` and `pkw` outputs.

The adopted convention is to treat `PKW` as passenger-car counts excluding vans:

```python
pkw_raw = Pkw_R1 + Pkw_R2
pkw = (pkw_raw - lfw).clip(lower=0)
```

This avoids double-counting light commercial vehicles in `pkw.csv`.

## Changes

### `scripts/build_mobility_profiles.py`

- Reads additional BASt columns:
  - `Bus_*`
  - `Lfw_*`
  - `LoA_*`
  - `Lzg_*`
  - `Sat_*`
  - plus the existing `KFZ` and `Pkw` columns.
- Builds and writes the following additional profiles:
  - `bus.csv`
  - `hd.csv`
  - `lfw.csv`
- These are written alongside the existing:
  - `kfz.csv`
  - `pkw.csv`
- All outputs follow the same schema:

```text
day, hour, count, n_counts
```

- Header comments list the source ZIP files used.
- Updates the `PKW` calculation as:

```python
pkw_raw = Pkw_R1 + Pkw_R2
pkw = (pkw_raw - lfw).clip(lower=0)
```

### `rules/build_sector.smk`

- Extends `build_mobility_profiles` outputs to include:
  - `bus`
  - `hd`
  - `lfw`

- Extends `build_transport_demand` inputs to include:
  - `traffic_data_Bus`
  - `traffic_data_HD`
  - `traffic_data_LFW`

- Extends `build_transport_demand` outputs to include:
  - `avail_profile_pkw`
  - `avail_profile_bus`
  - `avail_profile_hd`
  - `avail_profile_lfw`

- Keeps the existing outputs unchanged:
  - `transport_demand`
  - `transport_data`
  - `dsm_profile`

- Uses string paths for mobility CSV paths where `MOBILITY_PROFILES_DATASET["folder"]` is a string, avoiding invalid path concatenation.

### `scripts/build_transport_demand.py`

- Calls `vehicle_availability_profile` once per vehicle class using the matching traffic CSV and sector configuration keys:

```yaml
pkw_bev_avail_max / pkw_bev_avail_mean
bus_bev_avail_max / bus_bev_avail_mean
hd_bev_avail_max / hd_bev_avail_mean
lfw_bev_avail_max / lfw_bev_avail_mean
```

- Keeps the existing `build_transport_demand(...)` logic for the single `transport_demand` output.
- `transport_demand` is still based on:
  - `PKW` traffic
  - `passenger_car_pkm`
  - `passengers_per_movement`

### `config/config.eurelectric.default.yaml`

- Sets the mobility profiles dataset to local build mode:

```yaml
data:
  mobility_profiles:
    source: build
    version: latest
```

This is needed because the archive path only ships the legacy `kfz` and `pkw` profiles.

- Adds sector defaults for class-specific availability parameters:
  - `pkw_bev_avail_max`
  - `pkw_bev_avail_mean`
  - `bus_bev_avail_max`
  - `bus_bev_avail_mean`
  - `hd_bev_avail_max`
  - `hd_bev_avail_mean`
  - `lfw_bev_avail_max`
  - `lfw_bev_avail_mean`

### `Snakefile`

- If `config/config.eurelectric.default.yaml` exists, it is loaded so Eurelectric defaults apply without always passing `--configfile` manually.

## Follow-up / not in this PR

### `prepare_sector_network`

`prepare_sector_network` still consumes a single legacy availability profile input and calls `add_EVs` once.

Wiring the new outputs into separate vehicle-class loads, chargers, and optional V2G is left for a follow-up phase. This includes aligning:

```text
avail_profile_s_*
```

with:

```text
avail_profile_pkw_s_*
avail_profile_bus_s_*
avail_profile_hd_s_*
avail_profile_lfw_s_*
```

### `transport_data.csv`

No new annual activity columns are added yet for bus, heavy-duty, or light commercial vehicles.

Class-split temporal demand would require extending both:

- `build_transport_demand`
- nodal transport statistics

once robust vehicle-class activity statistics are defined.

## How to test

### 1. Build mobility profiles

```bash
snakemake build_mobility_profiles
```

Check the mobility profile build folder, for example:

```text
data/mobility_profiles/build/<version>/
```

Expected files:

```text
kfz.csv
pkw.csv
bus.csv
hd.csv
lfw.csv
```

The exact `<version>` depends on the label used in `versions.csv` for the local build dataset.

### 2. Build class-specific availability profiles

Run the relevant target for your cluster setting, for example:

```bash
snakemake resources/avail_profile_pkw_s_<clusters>.csv
```

or the equivalent target for the active `scenario.clusters`.

Verify that the following files are created:

```text
avail_profile_pkw_s_<clusters>.csv
avail_profile_bus_s_<clusters>.csv
avail_profile_hd_s_<clusters>.csv
avail_profile_lfw_s_<clusters>.csv
```

The expected shape should match:

```text
snapshots × nodes
```

### 3. Spot checks

- Check that `pkw` counts are consistent with:

```python
pkw = (pkw_raw - lfw).clip(lower=0)
```

after aggregation.

- Check that the traffic profiles show plausible daily and weekly patterns.
- Compare rush-hour shapes against `kfz.csv` to verify that the class-specific profiles are reasonable.