### PR TITLE
Do not limit charging for EVs to DSM profile without DSM

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2347,7 +2347,17 @@ def add_EVs(
         p_set=profile.loc[n.snapshots],
     )
 
-    # Add BEV chargers
+    if not options["bev_dsm"]:
+        # Without DSM, pass through the load profile of the EVs directly to the grid
+        # This means that the chargers are always available to meet any load
+        # but load is not shifted in time
+        charger_p_max_pu = 1.0
+    elif options["bev_dsm"]:
+        # With DSM, the chargers can only meet the load when EVs are available for charging/discharging
+        # according to the availability profile, which allows for shifting load in time
+        charger_p_max_pu = avail_profile.loc[n.snapshots, spatial.nodes]
+
+
     p_nom = number_cars * options["bev_charge_rate"] * electric_share
     n.add(
         "Link",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2367,7 +2367,7 @@ def add_EVs(
         bus1=spatial.nodes + f" EV battery {mode}",
         p_nom=p_nom,
         carrier=f"BEV charger {mode}",
-        p_max_pu=avail_profile.loc[n.snapshots, spatial.nodes],
+        p_max_pu=charger_p_max_pu,
         lifetime=1,
         efficiency=options["bev_charge_efficiency"],
     )


### PR DESCRIPTION
This PR addresses the need for enabling load shedding in the whole model to combat infeasibilities with EV demand.

What was causing the problem was limiting the EV charging link to the DSM availability profile even if no DSM Store was enabled and present. If the availability profile was < the momentary EV demand, the model became infeasibile, as without DSM there is not `Store` to shift the EV demand in time.

In this case the availability profile can be skipped and EV demand directly passed to the electricity bus by setting `p_max_pu = 1`, as this is what the model would need to do anyways due to a lack of `Store` at the EV bus.
(this also reduces the model complexity a bit).

Tested with `load_shedding` disabled and the model is not immediately infeasible.

Ready for review and merge @AbiAfthab @aceccatoeurelectric .